### PR TITLE
docs: document browser cache reuse and offline browser commands

### DIFF
--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -52,9 +52,26 @@ If `PUPPETEER_EXECUTABLE_PATH` is set, BSI treats that as the preferred browser:
 
 ### 2. Cached browser (medium priority)
 
-If no system browser is configured, BSI looks in the Puppeteer cache directory (for example `C:\Users\<user>\.cache\puppeteer` on Windows).
+If no system browser is configured, BSI looks in the Puppeteer cache directory (for example `C:\Users\<user>\.cache\puppeteer` on Windows, or `~/.cache/puppeteer` on macOS and Linux).
 
-If a compatible browser is found there, that browser is used and no download is needed.
+A cached browser is used when it matches **both** of these:
+
+- **Browser type** — the browser asked for with `--browser` (`chrome` or `firefox`).
+- **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly that build ID is used. If a different version is cached, BSI treats it as no match and downloads the version you asked for. If `--browser-version` is `latest` (the default), any cached build of the requested browser type is accepted.
+
+When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.
+
+Use `butler-sheet-icons browser list-installed` to see which browsers are currently cached, and `browser install` to add one deliberately — for example when preparing a machine that will later run without internet access.
+
+::: tip "latest" means "anything cached", not "the newest available"
+With `--browser-version latest`, BSI does **not** check whether a newer browser has been released. Any cached build of the requested type is accepted, so a cached browser never updates itself. To move to a newer build, install it explicitly with `browser install --browser chrome --browser-version <build id>`, or clear the cache with `browser uninstall-all` and let the next run download a fresh one.
+
+If several builds of the same browser are cached, do not rely on which one gets picked. Pin `--browser-version` to an exact build ID whenever the exact version matters.
+:::
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 3.12.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
+:::
 
 ### 3. Download browser (lowest priority)
 
@@ -65,6 +82,40 @@ If no system browser and no cached browser are found, BSI downloads a browser fr
 - Future runs can reuse this cached browser, including in air‑gapped environments (after the first download)
 
 If the environment has no internet access and no browser can be found via steps 1–2, BSI will fail with clear log messages.
+
+## Which browser commands need internet access?
+
+Creating thumbnails does not need internet access for the browser itself, as long as step 1 or step 2 above finds one. The `browser` management commands are different — only some of them reach out to the internet:
+
+| Command                              | Needs internet? |
+| ------------------------------------ | --------------- |
+| `browser list-installed`             | **No.** Reads the local Puppeteer cache only. |
+| `browser uninstall` / `uninstall-all` | **No.** Removes browsers from the local cache. |
+| `browser list-available`             | **Yes**, for Chrome. It asks Google's Chrome version history service which versions exist. (For Firefox the command only reports that `latest` is the sole supported version, and makes no network call.) |
+| `browser install`                    | **Yes**, always. BSI verifies that the requested build can actually be downloaded before installing it, so the command needs internet access even when that version is already in the cache. |
+
+On a machine with no internet access — an air-gapped server, or one behind a proxy that blocks outbound HTTPS — `browser list-available` reports:
+
+```
+error: Could not reach versionhistory.googleapis.com to look up available browser versions.
+error: Butler Sheet Icons needs internet access for this command. If this machine is offline or
+       behind a proxy, use "butler-sheet-icons browser list-installed" to see the browsers already
+       available locally.
+```
+
+This is expected, not a fault in BSI. Use `browser list-installed` to see what is already available on the machine.
+
+If the version history service is reachable but answers with an error, the message says so explicitly and quotes the HTTP status instead — so a proxy returning `403` is easy to tell apart from having no connectivity at all. A captive portal or intercepting proxy that answers with an HTML login page is reported as an unexpected response from the service.
+
+::: tip Preparing an offline machine
+Run `browser install` once while the machine still has internet access. The browser is stored in the Puppeteer cache and reused on every later run, so thumbnail creation itself works without connectivity.
+
+Setting `PUPPETEER_EXECUTABLE_PATH` to a browser installed by other means works too, and is the usual approach for Docker and centrally managed environments. See [Strategy 2](#strategy-2-use-a-system-browser-via-puppeteer-executable-path-controlled) and [Strategy 3](#strategy-3-use-a-pre-cached-browser-semi-offline) below.
+:::
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 3.12.0 the messages above are shown instead.
+:::
 
 ## Key environment variables
 
@@ -171,7 +222,7 @@ butler-sheet-icons qseow create-sheet-thumbnails `
   --imagedir .\img
 ```
 
-### Strategy 3: Use a pre‑cached browser (semi‑offline)
+### Strategy 3: Use a pre-cached browser (semi-offline)
 
 **Good for:** environments where you can briefly connect to the internet to pre‑download browsers, then run offline.
 

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -35,7 +35,7 @@ When running Butler Sheet Icons for the first time, you have several options. Th
 
 ### Automatic Download (Default)
 
-If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed):
+If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed). From BSI 3.12.0 the download happens only once — later runs find the browser in the cache and reuse it, needing no download and no internet access for the browser itself. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority) for the exact matching rules.
 
 ::: code-group
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -272,6 +272,60 @@ Browser-related problems are among the most common issues when using Butler Shee
    butler-sheet-icons browser install --browser chrome --browser-version latest
    ```
 
+### Browser Commands Fail on a Machine Without Internet Access
+
+**Symptoms:**
+
+- `browser list-available` reports that `versionhistory.googleapis.com` could not be reached
+- `browser install` reports that the requested version "cannot be downloaded"
+- On BSI versions before 3.12.0, `browser list-available` instead printed a raw stack trace such as `TypeError: Cannot read properties of undefined (reading 'status')`, with line numbers from inside the BSI binary
+
+**Cause:**
+
+Two of the `browser` commands need internet access, and the rest do not:
+
+| Command                               | Needs internet? |
+| ------------------------------------- | --------------- |
+| `browser list-installed`              | No              |
+| `browser uninstall` / `uninstall-all` | No              |
+| `browser list-available`              | Yes, for Chrome |
+| `browser install`                     | Yes, always     |
+
+On an air-gapped server, or one behind a proxy that blocks outbound HTTPS, the two commands that need internet access will fail. This is expected behaviour, not a fault in BSI.
+
+**Solutions:**
+
+1. **See what is already available locally** — this works offline:
+
+   ```bash
+   butler-sheet-icons browser list-installed
+   ```
+
+2. **Prepare the machine while it still has connectivity**:
+
+   ```bash
+   # Run once on a connected machine; the browser is cached and reused afterwards
+   butler-sheet-icons browser install --browser chrome --browser-version latest
+   ```
+
+3. **Or point BSI at a browser installed by other means** — no download and no internet access needed:
+
+   ::: code-group
+
+   ```powershell [PowerShell]
+   $env:PUPPETEER_EXECUTABLE_PATH = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+   ```
+
+   ```bash [Bash]
+   export PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium-browser"
+   ```
+
+   :::
+
+4. **If a proxy is in the way**, and the service is reachable but answers with an error, BSI reports the HTTP status instead (for example `403`). That points at proxy rules rather than missing connectivity — see [Proxy Configuration](/guide/advanced/proxy).
+
+Creating thumbnails itself does not need internet access once a browser is available locally. For the full picture, see [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access).
+
 ### Browser Runtime Crashes
 
 **Symptoms:**

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -18,14 +18,16 @@ butler-sheet-icons browser [command] [options]
 
 ### Available Commands
 
-| Command          | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `list-installed` | Show which browsers are currently installed and available for use by BSI |
-| `list-available` | Show which browsers are available for download and installation          |
-| `install`        | Install a browser into the BSI cache                                     |
-| `uninstall`      | Uninstall a specific browser from the BSI cache                          |
-| `uninstall-all`  | Uninstall all browsers from the BSI cache                                |
-| `help`           | Display help for browser commands                                        |
+| Command          | Description                                                              | Needs internet? |
+| ---------------- | ------------------------------------------------------------------------ | --------------- |
+| `list-installed` | Show which browsers are currently installed and available for use by BSI | No              |
+| `list-available` | Show which browsers are available for download and installation          | Yes (Chrome)    |
+| `install`        | Install a browser into the BSI cache                                     | Yes             |
+| `uninstall`      | Uninstall a specific browser from the BSI cache                          | No              |
+| `uninstall-all`  | Uninstall all browsers from the BSI cache                                | No              |
+| `help`           | Display help for browser commands                                        | No              |
+
+On a machine without internet access, only the commands marked "No" above will work. See [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access) for what the offline failures look like and how to prepare an air-gapped machine.
 
 ## Commands Reference
 
@@ -90,6 +92,19 @@ butler-sheet-icons browser list-available [options]
 Note the build IDs (e.g., 121.0.6167.85) in the output. These are the exact identifiers to use when installing specific Chrome versions.
 :::
 
+::: warning Needs internet access
+For Chrome, this command asks Google's Chrome version history service which versions exist, so it only works on a machine that can reach the internet. On an offline machine, or behind a proxy that blocks outbound HTTPS, it reports:
+
+```
+error: Could not reach versionhistory.googleapis.com to look up available browser versions.
+error: Butler Sheet Icons needs internet access for this command. If this machine is offline or
+       behind a proxy, use "butler-sheet-icons browser list-installed" to see the browsers already
+       available locally.
+```
+
+Use `browser list-installed` instead to see what is already available locally. For Firefox, the command makes no network call — it simply reports that `latest` is the only supported version.
+:::
+
 ### install
 
 Downloads and installs a browser into the BSI cache. By default, installs the latest stable version of Chrome.
@@ -146,6 +161,10 @@ Install latest Firefox (macOS):
 
 ::: warning Older Chrome Versions
 If you try to install an older Chrome version that's no longer available, you'll get a 404 error. The Chrome team periodically removes older versions from their download servers. Use a newer version instead.
+:::
+
+::: warning Needs internet access
+`browser install` always needs internet access — it verifies that the requested build can actually be downloaded before installing it, so the check runs even when that version is already in the cache. Run it once while the machine is connected; the browser is then stored in the cache and reused on later runs without connectivity. See [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access).
 :::
 
 ### uninstall
@@ -311,13 +330,15 @@ butler-sheet-icons qseow create-sheet-thumbnails \
 
 ## Browser Cache Location
 
-BSI stores browsers in platform-specific cache directories:
+BSI stores browsers in a cache directory under the home directory of the user running BSI:
 
 - **Windows:** `%USERPROFILE%\.cache\puppeteer\`
-- **macOS:** `~/Library/Caches/puppeteer/` or `~/.cache/puppeteer/`
+- **macOS:** `~/.cache/puppeteer/`
 - **Linux:** `~/.cache/puppeteer/`
 
 These directories contain the actual browser binaries and are managed automatically by BSI.
+
+Because the cache lives under the user's home directory, a browser installed by one user account is not visible to another. When BSI runs as a service account — for example from a scheduled task — install the browser as that same account, or point all accounts at one shared browser with `PUPPETEER_EXECUTABLE_PATH`.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Type of Change

Content update / Bug fix (incorrect info)

## Description

Documents two browser behaviours that change in Butler Sheet Icons 3.12.0, published from the staged drafts in ptarmiganlabs/butler-sheet-icons#851.

**Cached browser reuse.** The detection-order page described step 2 as an intention, but until 3.12.0 a defect meant no cached browser was ever found — BSI re-downloaded a browser on *every run* unless `PUPPETEER_EXECUTABLE_PATH` was set. The page now states the matching rules (browser type plus an exact build id, or any cached build when `--browser-version` is `latest`) and the two consequences that follow from the implementation: a cached browser never updates itself, and with several builds cached the selection is not predictable. That second point is tracked as ptarmiganlabs/butler-sheet-icons#850.

**Offline browser commands.** Only `list-available` and `install` reach the internet. Before 3.12.0, running `list-available` on an offline machine printed a stack trace with line numbers from inside the bundled binary rather than an explanation. The page now covers which commands need connectivity, what the new messages say, and how to prepare an air-gapped machine.

The offline guidance went on the existing concept page rather than a new one — #809 and #810 will want a single home for air-gapped guidance, and two partial descriptions would drift apart.

Both behaviours are gated behind `::: warning Requires BSI 3.12.0 or later` callouts, so the pages stay correct for readers still on 3.11.0.

### Two corrections found while writing

- The browser reference listed `~/Library/Caches/puppeteer/` as a macOS cache location. BSI hardcodes `homedir()/.cache/puppeteer` on every platform. Also added a note that the cache is per-user, which matters when BSI runs as a service account under a scheduled task.
- The Strategy 3 heading used non-breaking hyphens (U+2011), so its anchor could not be linked with an ASCII hyphen. Normalised to plain hyphens.

## Pages/Sections Affected

- `docs/guide/concepts/browser-detection-and-environment-variables.md` — rewrote "2. Cached browser", added "Which browser commands need internet access?"
- `docs/reference/browser.md` — internet column on the command table, offline callouts on `list-available` and `install`, corrected macOS cache path
- `docs/guide/troubleshooting.md` — new symptom → cause → fix entry under Browser Issues
- `docs/guide/concepts/browser-management.md` — one line on download-once-reuse-after

No new pages, so `docs/.vitepress/config.js` is unchanged.

## Testing

- Built successfully with `npm run docs:build`
- Every added link verified in the generated HTML. The build fails on dead page links but does **not** validate `#anchor` fragments, so each anchor was checked against the `id` attributes in `docs/.vitepress/dist` — this caught the U+2011 heading above.
- No images added.

## Content Quality

Claims verified against the implementation in the butler-sheet-icons repo rather than taken from the drafts — the drafts were wrong about `browser install` needing internet only when uncached (`canDownload()` runs a network HEAD before `install()`, so it always needs it). Error message text is quoted verbatim from the source so administrators can search for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
