### PR TITLE
chore: remove the commented-out GitHub Pages deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,17 +46,3 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/.vitepress/dist
-
-  # Deployment job
-  # Do not deploy for now. Use manual deployment instead, using "npm run deploy".
-  # deploy:
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   name: Deploy
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Type of Change

Configuration/technical update

## Description

`.github/workflows/deploy.yml` carried a commented-out deployment job with the note:

> Do not deploy for now. Use manual deployment instead, using "npm run deploy".

That instruction is stale and misleading. `npm run deploy` publishes to the `gh-pages` branch, which has not been touched since 2026-06-12 (its last commit is literally "Delete CNAME"). The live site at butler-sheet-icons.ptarmiganlabs.com is served by **Cloudflare Pages**, which builds from `main` directly — confirmed by response headers and by the fact that PR #31 appeared on the live site immediately on merge, with no manual step.

So a contributor following the note would push a build somewhere nothing reads, and reasonably conclude the site was broken.

The `build` job is kept. It still validates that the site compiles on every push to `main`, and VitePress fails the build on dead links, so it has standing value as a check.

## Pages/Sections Affected

- `.github/workflows/deploy.yml` — removed the 13 commented-out lines

No documentation content changes.

## Testing

- Verified the remaining workflow still parses and that the `build` job is intact
- No content changes, so no `npm run docs:build` diff to review

## Additional Notes

Two related things left alone deliberately, worth a follow-up decision:

- The workflow's `permissions:` block still grants `pages: write` and `id-token: write`, which existed only for the deleted deploy job. With no deploy step, `contents: read` alone would do.
- The workflow name is still "Deploy VitePress site to Pages" though it only builds now.

Both are outside the scope of "remove the commented-out job" — happy to fold them in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
