### PR TITLE
fix: make the pull request template render, correct release procedure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -227,29 +227,9 @@ For issues with the tool itself, use the [main repository](https://github.com/pt
 
 ### Pull Request Template
 
-```markdown
-## Description
-
-Brief description of changes made.
-
-## Type of Change
-
-- [ ] Documentation update
-- [ ] New content
-- [ ] Bug fix (broken link, typo, etc.)
-- [ ] Enhancement (improved explanation, new examples)
-
-## Testing
-
-- [ ] Tested locally with `npm run docs:dev`
-- [ ] Verified all links work
-- [ ] Checked images display correctly
-- [ ] Built successfully with `npm run docs:build`
-
-## Additional Notes
-
-Any additional context or considerations.
-```
+GitHub fills the PR description from [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md)
+automatically — there is nothing to copy by hand. Work through its checklist before requesting
+review.
 
 ### Review Process
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,82 +1,28 @@
-name: Pull Request
-description: Submit changes to the documentation
-title: ''
+## Description
 
-body:
+<!-- What changed, and why. -->
 
-- type: markdown
-  attributes:
-  value: |
-  Thank you for contributing to the Butler Sheet Icons documentation! Please provide details about your changes.
+## Type of change
 
-- type: dropdown
-  id: change-type
-  attributes:
-  label: Type of Change
-  description: What type of change are you making?
-  multiple: true
-  options: - Bug fix (typo, broken link, incorrect info) - Content update (new information, examples) - New documentation (new pages, sections) - Enhancement (improved explanations, reorganization) - Visual improvements (images, formatting) - Configuration/technical updates
-  validations:
-  required: true
+- [ ] Fix (typo, broken link, incorrect information)
+- [ ] Content update (new information or examples on an existing page)
+- [ ] New page
+- [ ] Enhancement (clearer explanation, reorganisation)
+- [ ] Repository/tooling change (config, workflows, dependencies)
 
-- type: textarea
-  id: description
-  attributes:
-  label: Description
-  description: Describe the changes you made and why
-  placeholder: This PR adds documentation for... / This PR fixes...
-  validations:
-  required: true
+## Pages affected
 
-- type: textarea
-  id: pages-affected
-  attributes:
-  label: Pages/Sections Affected
-  description: List the pages or sections you modified
-  placeholder: | - /guide/quick-start.md - /examples/qscloud.md - docs/.vitepress/config.js (navigation)
+<!-- e.g. /guide/quick-start, /reference/commands, docs/.vitepress/config.js (sidebar) -->
 
-- type: checkboxes
-  id: testing
-  attributes:
-  label: Testing Checklist
-  description: Please confirm you have tested your changes
-  options: - label: Tested locally with `npm run docs:dev`
-  required: true - label: Verified all links work correctly
-  required: true - label: Checked that images display properly
-  required: true - label: Built successfully with `npm run docs:build`
-  required: true - label: Previewed production build with `npm run docs:preview`
-  required: false
+## Checklist
 
-- type: checkboxes
-  id: content-quality
-  attributes:
-  label: Content Quality
-  description: Please confirm your changes meet quality standards
-  options: - label: Content is accurate and tested
-  required: true - label: Writing is clear and follows existing style
-  required: true - label: Examples are practical and working
-  required: false - label: Cross-references are updated where needed
-  required: false - label: Images have descriptive alt text
-  required: false
+- [ ] This PR targets `next` — see [Which branch?](../blob/next/.github/CONTRIBUTING.md#which-branch)
+- [ ] `npm run docs:build` passes locally (the build fails on dead internal links)
+- [ ] Internal links are absolute and extensionless, e.g. `/guide/quick-start`
+- [ ] New pages have a sidebar entry in `docs/.vitepress/config.js`
+- [ ] Images display correctly and have descriptive alt text
+- [ ] Checked the Cloudflare Pages preview link once the build finishes
 
-- type: textarea
-  id: screenshots
-  attributes:
-  label: Screenshots (if applicable)
-  description: Include screenshots of UI changes or new content
+## Notes for reviewers
 
-- type: textarea
-  id: additional-notes
-  attributes:
-  label: Additional Notes
-  description: Any other information that reviewers should know
-
-- type: checkboxes
-  id: final-checks
-  attributes:
-  label: Final Verification
-  description: Please confirm
-  options: - label: I have read the contributing guidelines
-  required: true - label: My changes follow the project coding standards
-  required: true - label: I have updated navigation/config if adding new pages
-  required: false
+<!-- Anything worth knowing: decisions taken, things deliberately left out, follow-up work. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,14 @@ which is a separate maintenance step documented in [README_DEPLOY.md](./README_D
 Writing to `main` directly is a deliberate production hotfix, not a normal option. Do not choose
 it without being asked to.
 
+One narrow exception: GitHub reads the pull request template and the issue templates under
+`.github/` **only from the default branch**, so a change to those has no effect until it is on
+`main` and targets `main` directly. This does not extend to anything under `docs/` — that is site
+content and always goes to `next`.
+
+A repository ruleset requires a pull request for `main` and rejects direct and force pushes. No
+approvals are required.
+
 ## Where new documentation comes from
 
 Most new content originates in the **BSI repo**, not here. Behaviour changes are staged there as

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -57,14 +57,24 @@ The cost is that a correction to an already-live page waits for the next release
 If something on production genuinely cannot wait, that is a deliberate hotfix branched
 off `main` — an exception, not one of two normal options.
 
+There is one other narrow exception. GitHub reads a few repository files **only from the
+default branch**, `main` — the pull request template and the issue templates under
+`.github/`. A fix to those has no effect until it is on `main`, so it targets `main`
+directly. This does not extend to anything under `docs/`, which is site content and
+always goes to `next`.
+
 ### At release time
 
 Order matters, because the version label in the site nav follows the **latest GitHub
 release** of Butler Sheet Icons (see "Version label" below):
 
 1. Release Butler Sheet Icons first, so `releases/latest` points at the new version.
-2. Merge `next` → `main`.
+2. Open a pull request from `next` into `main` and merge it. A repository ruleset
+   requires a pull request for `main` — direct pushes and force pushes are rejected —
+   though no approvals are required, so you can merge your own.
 3. Cloudflare publishes; the nav label picks up the new version on that build.
+4. Update `BSI_DOCS_VERSION` on the Cloudflare **preview** environment to the next
+   upcoming version, or clear it. It does not update itself.
 
 Merging before the BSI release ships puts new content on the site under the *old*
 version number for however long the gap lasts.


### PR DESCRIPTION
## Why this targets `main` and not `next`

Deliberate exception, agreed before opening. GitHub reads `.github/PULL_REQUEST_TEMPLATE.md` **only from the default branch**, so merging this to `next` would leave the broken template live in the UI until 3.12.0 ships — every PR opened in the meantime would get the garbage. The next-only rule exists to stop unreleased *documentation* reaching the public site; a PR template is not published content, so it sits outside that rule's intent.

The exception is now written down in `README_DEPLOY.md` and `CLAUDE.md` so it does not have to be re-argued. It is narrow: `.github/` templates only, never anything under `docs/`.

## 1. The pull request template did not render

`.github/PULL_REQUEST_TEMPLATE.md` contained GitHub **issue form** YAML — `name:`, `body:`, `- type: dropdown`, `validations:`. Pull request templates are plain markdown; issue-form syntax is not supported there, so the entire file rendered as literal text in every PR description. Including the two merged earlier today.

Replaced with plain markdown, trimmed from six sections and ~20 checkboxes to something a contributor will actually complete. Added a checkbox confirming the PR targets `next`, and one for checking the Cloudflare preview.

`CONTRIBUTING.md` also carried a second, already-diverging copy of the template inline. Replaced with a pointer to the real file — GitHub fills the description in automatically, so there was never anything to copy by hand.

## 2. Release procedure was stale within the hour

The new ruleset requires a pull request for `main`, so "merge `next` → `main`" is no longer literally what happens. Corrected, and noted that no approvals are required so you can merge your own.

Also added the step that was missing: `BSI_DOCS_VERSION` on the Cloudflare preview environment has to be bumped after each release. It does not update itself, and forgetting it leaves the preview labelled with the version that just shipped. See #37.

## Verification

`npm run docs:build` passes. No content under `docs/` changed.

The template itself can only really be verified once merged — the next PR opened after this lands should show the rendered checklist.

Closes the PR-template item; the Cloudflare environment variables are tracked separately in #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)