### PR TITLE
docs: exit codes, run failures and once-per-app saving (BSI 3.12.0)

### DIFF
--- a/docs/guide/advanced/ci-cd.md
+++ b/docs/guide/advanced/ci-cd.md
@@ -144,14 +144,57 @@ export http_proxy='http://username:password@proxy.example.com:port'
 export https_proxy='http://username:password@proxy.example.com:port'
 ```
 
+## Exit codes and job status
+
+::: danger Action may be required — requires BSI 3.12.0 or later
+This change can turn a scheduled job that always reported success into one that reports failure. That is intended, but read this before upgrading so it does not surprise you at 3am.
+:::
+
+Until BSI 3.12.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
+
+BSI now exits `1` when the run failed or completed with apps it could not process. See [Exit codes](/reference/commands#exit-codes) for exactly what counts as a failure.
+
+### Before you upgrade
+
+**If you only run BSI interactively, there is nothing to do** — the exit code is not something you normally see.
+
+**If you run it from automation, check what your job does with a non-zero exit code.** Most schedulers treat it as a failed job and may raise an alert, stop the pipeline, or skip later steps.
+
+Run your existing command once by hand after upgrading and inspect the exit code:
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons qscloud create-sheet-thumbnails --tenanturl $env:BSI_TENANT_URL --apikey $env:BSI_API_KEY
+Write-Host "exit code: $LASTEXITCODE"
+```
+
+```bash [Bash]
+butler-sheet-icons qscloud create-sheet-thumbnails --tenanturl "$BSI_TENANT_URL" --apikey "$BSI_API_KEY"
+echo "exit code: $?"
+```
+
+:::
+
+**If it returns `1`, that is a real problem that was already happening** — it was simply invisible before. Read the log for the messages listed in [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes) and fix the underlying cause.
+
+If you need the job to keep running while you investigate, most schedulers let you ignore a step's exit code. Treat that as temporary: the exit code is telling you that sheet icons are not being updated the way you asked.
+
+### Retrying a failed run
+
+An app is saved once, after all its sheets have been dealt with. If that save fails, nothing about the app changes and its sheets keep the icons they had, so re-running is a clean retry rather than a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).
+
 ## Troubleshooting in CI
 
 - Use `--headless true` (default) on build agents. Consider `--headless false` only for local debugging.
 - For QSEoW, always provide `--sense-version` that matches your server.
 - In Qlik Cloud, updating published apps affects only private sheets—use sheet status filters to avoid “Access denied”.
+- A non-zero exit code is now meaningful — see [Exit codes and job status](#exit-codes-and-job-status) above.
 
 ## Related
 
-- Environment Variables: naming scheme and examples
-- Docker Usage: tips and troubleshooting for running BSI in containers
-- Sheet Exclusion and Sheet Blurring: control visibility vs. privacy in pipelines
+- [Exit codes](/reference/commands#exit-codes): what `0` and `1` mean, and what counts as a failure
+- [Environment variables](/guide/concepts/environment-variables): naming scheme and examples
+- [Docker usage](/guide/advanced/docker): tips and troubleshooting for running BSI in containers
+- [Sheet exclusion](/guide/concepts/sheet-exclusion) and [Sheet blurring](/guide/concepts/sheet-blurring): control visibility vs. privacy in pipelines
+- [Troubleshooting](/guide/troubleshooting): symptom-based diagnosis

--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -39,6 +39,23 @@ graph TD
 
 1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages.
 
+1. Save the app — Once every sheet has been dealt with, the app is saved **once**. See below.
+
+### When the app is saved
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions saved the app once per sheet.
+:::
+
+Butler Sheet Icons saves each app a single time, at the end of processing it, and only if at least one sheet actually changed.
+
+This matters in two ways:
+
+- **App version history.** An app with forty sheets used to gain forty versions in Qlik Sense on every run. It now gains one. An app where nothing needed changing gains none at all.
+- **Failed runs change nothing.** Because the save happens after every sheet has been handled, a run that fails before it — a published app, or one the account running Butler Sheet Icons cannot write to — leaves the app **completely untouched**, with its sheets keeping the icons they had. Previously the sheets processed before the failure had already been written, leaving the app with a mix of old and new icons.
+
+Re-running after a failure is therefore a clean retry rather than a resume. See [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes).
+
 ## Tips and pointers
 
 - Toggle headless mode or slow down navigation when debugging. See [Browser management](/guide/concepts/browser-management).
@@ -56,3 +73,5 @@ graph TD
 - Configuration (QSEoW): [/guide/configuration/qseow](/guide/configuration/qseow)
 - Commands reference: [/reference/commands](/reference/commands)
 - Browser reference: [/reference/browser](/reference/browser)
+- Exit codes: [/reference/commands#exit-codes](/reference/commands#exit-codes)
+- Run failures and exit codes: [/guide/troubleshooting#run-failures-and-exit-codes](/guide/troubleshooting#run-failures-and-exit-codes)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -31,6 +31,72 @@ butler-sheet-icons qscloud create-sheet-icons --headless false
 butler-sheet-icons browser list-installed
 ```
 
+## Run Failures and Exit Codes
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions always exited with `0`. If your automation never reported a failure before upgrading, that is why — see [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status).
+:::
+
+An exit code of `1` means the run failed, or finished with apps it could not process. Butler Sheet Icons logs a reason. Match the message you see below.
+
+### `Failed to process N of M app(s)`
+
+Some apps in the run could not be processed. The other apps were still attempted — one bad app does not stop the rest — and this line is the summary at the end.
+
+Each failed app has its own line earlier in the log naming the cause:
+
+```
+CLOUD PROCESS APP: Failed to process app b: engine unreachable
+Failed to process 1 of 3 app(s)
+```
+
+**What to do:** find the per-app lines and treat each cause separately. They are ordinary failures — an unreachable engine, an app the account cannot write to, a published app — and are covered by the sections below.
+
+### `No apps to process`
+
+The options you supplied matched no apps at all. This is reported as a failure, not a silent success: work was requested and none happened.
+
+```
+No apps to process. Check the --appid and --collectionid options.
+```
+
+On Qlik Sense Enterprise on Windows the hint names `--appid` and `--qliksensetag` instead.
+
+**What to do:** check the selection options themselves. Common causes are a collection that exists but contains no apps, a tag that no app carries, or an app ID that has been deleted. On QS Cloud, `butler-sheet-icons qscloud list-collections` shows which collections exist.
+
+### `Failed to update N of M sheet(s) in app <id>`
+
+One or more sheets in an app could not be updated, or their icons could not be removed. The app is reported as failed, and therefore so is the run.
+
+```
+CLOUD UPDATE SHEETS: Failed to update sheet 1 ('Sales overview', ID abc-123) in app 97089caf: Sheet is read-only
+Failed to update 1 of 2 sheet(s) in app 97089caf
+```
+
+Every other sheet is still attempted first, and the engine session is always released — only at the end is the app reported as failed.
+
+**Reading the counts:** the number is of sheets Butler Sheet Icons **tried** to update. Sheets deliberately left alone — because you excluded them, or because no thumbnail was generated for them — are counted in neither figure. So "1 of 2" means two sheets were attempted and one failed, regardless of how many sheets the app has in total.
+
+The per-sheet line names the sheet by title and ID, which is what you need to find it in Qlik Sense. The number is the sheet's position in the app, counting from 1.
+
+**What to do:** open the named sheet. A read-only or published sheet cannot be updated by the account BSI is running as. See [App Access Issues](#app-access-issues).
+
+### `Connection test to tenant ... returned a response with no user in it`
+
+The Qlik Sense Cloud connection test reached something, but the response did not describe a user.
+
+```
+Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no user in it. Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.
+```
+
+In earlier versions this printed `Connection to tenant … successful.` followed by four lines reading `undefined`, and the run then failed later for reasons that looked unrelated.
+
+**What to do:** verify `--tenanturl` points at a Qlik Sense Cloud tenant and that `--apikey` is valid and unexpired. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
+
+### The run failed — has anything changed in Qlik Sense?
+
+An app is saved once, after all of its sheets have been dealt with. If the run fails before that save, **nothing about the app changes** and its sheets keep the icons they had. Re-running is a clean retry, not a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).
+
 ## Authentication Issues
 
 ### QS Cloud Authentication Problems

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -47,6 +47,31 @@ These options are available for most commands:
 - `debug` - Debug information
 - `silly` - Everything including websocket traffic
 
+## Exit codes
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions always exited with `0`, whatever happened during the run.
+:::
+
+Every command reports its outcome in the process exit code:
+
+| Exit code | Meaning                                                                       |
+| --------- | ----------------------------------------------------------------------------- |
+| `0`       | The command completed, and everything it was asked to do succeeded.           |
+| `1`       | The command failed, or finished with one or more apps it could not process.   |
+
+### What counts as a failure
+
+- **An app that could not be processed.** Other apps in the same run are still attempted — one bad app does not stop the rest — but the run reports failure at the end.
+- **A connection that could not be established** to the Qlik Sense server or Qlik Sense Cloud tenant.
+- **A selection that matched no apps at all**, for example a `--collectionid` that exists but contains no apps, or a `--qliksensetag` that no app carries. Work was requested and none happened, so this is a failure rather than a silent no-op.
+- **A sheet that could not be updated, or whose icon could not be removed.** The remaining sheets in that app are still attempted; the app is reported as failed at the end.
+- **A Qlik Sense Cloud connection test that returns a response containing no user.**
+
+If you run Butler Sheet Icons from a scheduled task, CI pipeline or shell script, read [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status) before upgrading — a job that always reported success may start reporting failure.
+
+For the log messages that accompany a non-zero exit code, see [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes) in Troubleshooting.
+
 ## Detailed command references
 
 Use these pages for complete, per-platform command details:


### PR DESCRIPTION
Publishes `docs/to-doc-site/exit-code-now-reflects-failures.md` from the butler-sheet-icons repo.

Targets `next` — this documents BSI 3.12.0, which has not shipped.

## Why it is split across four pages

The draft bundled three topics. Publishing it as one page would have put reference facts, upgrade guidance and a mechanism change in the same place, so it is cut per page type instead.

The site had **no exit code documentation at all** — two incidental mentions on the crash dumps page and nothing else.

| Page | Created/edited | What went in |
|---|---|---|
| `/reference/commands` | Edited | New "Exit codes" section: the `0`/`1` table and what counts as a failure. Reference facts, no alarm. |
| `/guide/advanced/ci-cd` | Edited | New "Exit codes and job status": the automation consequence, the pre-upgrade check, retry behaviour. This is the audience the change disrupts. |
| `/guide/troubleshooting` | Edited | New "Run Failures and Exit Codes": the four new log messages, symptom → cause → fix. |
| `/guide/concepts/how-it-works` | Edited | New "When the app is saved": once per app, version history, and why a failed run now changes nothing. |

A dedicated `/reference/exit-codes` page was considered and rejected — `commands.md` was only 72 lines and already holds cross-command behaviour, so a new page plus sidebar entry would have fragmented it. No sidebar changes were needed.

## Verified against the implementation

Every claim was checked against source rather than trusted from the draft. All held:

| Claim | Source |
|---|---|
| Exit code 1 on failure | `src/lib/commands/run-command.js:31,39` |
| `Failed to process N of M app(s)` | `src/lib/util/run-over-apps.js:70` |
| `No apps to process.` + per-platform hint | `src/lib/util/run-over-apps.js:49` |
| Empty selection is a failure, not a no-op | `run-over-apps.js` — explicit code comment |
| `Failed to update N of M sheet(s) in app <id>` | `src/lib/util/sheet-list.js:294` |
| The count is of *attempted* sheets | `sheet-list.js` — `attempted` vs `skipped` |
| Save once at the end, only if something changed | `sheet-list.js:333` `saveIfChanged` |
| Failed run leaves the app untouched | `sheet-list.js:318` — documented trade-off |
| Tenant "no user in it" message | `src/lib/cloud/cloud-test-connection.js:50` |
| `--collectionid` (cloud) vs `--qliksensetag` (QSEoW) hint | `cloud-create-thumbnails.js:136`, `qseow-create-thumbnails.js:91` |

One implementation detail deliberately **not** documented: BSI sets `process.exitCode` rather than calling `process.exit()`. No user-visible difference.

## Also fixed

`ci-cd.md`'s "Related" section listed page names as plain text, not links. Now links.

## Verification

`npm run docs:build` passes. Anchors are not build-validated, so all six cross-reference fragments were checked against the generated HTML — `#exit-codes`, `#exit-codes-and-job-status`, `#run-failures-and-exit-codes`, `#app-access-issues`, `#qs-cloud-authentication-problems`, `#what-happens-at-each-step`. All resolve.

## Known seam

Two other pending drafts — `one-bad-sheet-no-longer-fails-the-app.md` and `failed-uploads-no-longer-break-sheet-icons.md` — cover adjacent per-sheet and "app left untouched" behaviour. The troubleshooting entries added here will want cross-links to those once they are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)