### PR TITLE
docs: document how to run and view the site locally

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,25 @@ npm run docs:preview      # Preview production build locally
 
 There is no deploy script. Deployment is automatic — see "Deployment & Hosting" below.
 
+### Viewing the site locally
+
+Run the dev server and open it in a browser to see changes rendered:
+
+```bash
+npm run docs:dev
+```
+
+The server runs until stopped. Open the URL printed at the end of its output — **read the port from that output rather than assuming 5173**, because VitePress falls back to 5174, 5175 and so on when the port is taken:
+
+```
+  ➜  Local:   http://localhost:5174/
+```
+
+Two things worth knowing about the dev server:
+
+- **`curl` will not show page content.** It returns an empty SPA shell and renders client-side, so grepping the response for a heading you just added finds nothing even when the page is fine. Use a browser, or build with `npm run docs:build` and read `docs/.vitepress/dist/` for static HTML.
+- **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected** on startup and harmless.
+
 ## Content Guidelines
 
 ### Writing Style

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,16 @@ Two things worth knowing about the dev server:
 - **`curl` will not show page content.** It returns an empty SPA shell and renders client-side, so grepping the response for a heading you just added finds nothing even when the page is fine. Use a browser, or build with `npm run docs:build` and read `docs/.vitepress/dist/` for static HTML.
 - **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected** on startup and harmless.
 
+### Always share the Cloudflare preview URL
+
+Every pushed branch is built by Cloudflare Pages and published to its own URL. **Include that URL whenever you report work on a branch** — it lets the change be reviewed rendered, without checking anything out.
+
+Read it from the "Cloudflare Pages" check run on the branch's head commit rather than constructing it. Give the branch alias, which follows the branch; the other URL in that output is pinned to a single commit.
+
+**The alias is not simply the branch name.** Cloudflare lowercases it, replaces non-alphanumeric characters with `-`, and truncates to 28 characters, so `docs/exit-code-reflects-failures` becomes `docs-exit-code-reflects-fail.butler-sheet-icons-docs.pages.dev`. Guessed URLs 404 for anything longer.
+
+Allow a minute or two after pushing for the build to finish, and say so when a branch has no rendered changes to look at.
+
 ## Content Guidelines
 
 ### Writing Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,42 @@ Two things about the dev server that will otherwise waste your time:
 
 Stop the server when you are done.
 
+## Always give the user the Cloudflare preview URL
+
+Every branch pushed to GitHub is built by Cloudflare Pages and published to its own URL. **Include
+that URL whenever you report work on a branch.** It is how the user reviews rendered output without
+checking anything out, and it works from any device.
+
+Read it from the Cloudflare Pages check run rather than constructing it:
+
+```bash
+sha=$(gh pr view <PR> --repo ptarmiganlabs/butler-sheet-icons-docs --json headRefOid --jq '.headRefOid')
+gh api repos/ptarmiganlabs/butler-sheet-icons-docs/commits/$sha/check-runs \
+  --jq '.check_runs[]|select(.name|test("Cloudflare"))|.output.summary'
+```
+
+That output contains two URLs. Give the **branch alias** — it follows the branch as you push more
+commits. The other is pinned to a single commit (an 8-hex-character prefix); use it only when you
+deliberately want a link that will not move.
+
+**Do not assume the alias is the branch name.** Cloudflare lowercases it, replaces every
+non-alphanumeric character with `-`, and **truncates to 28 characters**:
+
+| Branch | Alias |
+| --- | --- |
+| `next` | `next.butler-sheet-icons-docs.pages.dev` |
+| `docs/exit-code-reflects-failures` | `docs-exit-code-reflects-fail.butler-sheet-icons-docs.pages.dev` |
+| `docs/local-testing-instructions` | `docs-local-testing-instructi.butler-sheet-icons-docs.pages.dev` |
+
+Branch names over 28 characters are cut mid-word, so a guessed URL 404s. Read it from the check run.
+
+Two things to mention alongside the link when they apply:
+
+- The build takes a minute or two after a push, so a URL given immediately may 404 briefly.
+- A branch with no rendered changes — one that only touches `CLAUDE.md`, workflows or other
+  repository files — has nothing to look at. Say so rather than sending the user to an identical
+  page.
+
 ## Verify before reporting done
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,36 @@ reviewable without diffing the branch.
   only by search.
 - Write for **Qlik Sense administrators**, not Node.js developers.
 
+## Testing the site locally
+
+You can run the site and look at it yourself. Do this whenever a change is visual, structural, or
+worth seeing rendered — do not ask the user to check something you can check.
+
+```bash
+npm run docs:dev
+```
+
+The server runs until stopped, so start it in the background. Then open the URL printed at the end
+of its output in a browser and navigate the site as a reader would.
+
+**Read the port from that output — do not assume 5173.** VitePress falls back to 5174, 5175 and so
+on whenever the port is already taken, which happens often:
+
+```
+  ➜  Local:   http://localhost:5174/
+```
+
+Two things about the dev server that will otherwise waste your time:
+
+- **`curl` cannot see page content.** The dev server returns an empty SPA shell and renders
+  everything client-side, so `curl … | grep 'my new heading'` finds nothing even when the page is
+  perfectly fine. Use a real browser. If you want HTML you can grep, run `npm run docs:build` and
+  read `docs/.vitepress/dist/` instead.
+- **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected noise.**
+  It appears on most starts and the server works regardless. Do not chase it.
+
+Stop the server when you are done.
+
 ## Verify before reporting done
 
 ```bash
@@ -73,7 +103,7 @@ npm run docs:build
 
 Fails on dead internal links, so a passing build proves every internal link resolves. It does
 **not** validate `#anchor` fragments — check those against the generated HTML in
-`docs/.vitepress/dist/`.
+`docs/.vitepress/dist/`, e.g. `grep -o 'id="[^"]*"' docs/.vitepress/dist/reference/commands.html`.
 
 ## Deployment
 


### PR DESCRIPTION
Neither `CLAUDE.md` nor `.github/copilot-instructions.md` explained how to actually look at the site. An agent making a visual or structural change had no documented way to see the result, so it got handed back to the maintainer to check.

## What was added

`npm run docs:dev`, then open the URL from its output in a browser.

Plus two traps, both found by running it rather than by reading the config:

**The port is not always 5173.** VitePress falls back to 5174, 5175 and so on whenever the port is already taken — which happened on the very first run while writing this:

```
Port 5173 is in use, trying another one...
  ➜  Local:   http://localhost:5174/
```

An agent that hardcodes 5173 connects to whatever unrelated server is already there, or to nothing.

**`curl` cannot see page content on the dev server.** It returns an empty SPA shell and renders everything client-side:

```html
<body>
  <div id="app"></div>
  <script type="module" src="/@fs/…/vitepress/dist/client/app/index.js"></script>
</body>
```

So `curl … | grep 'my new heading'` finds nothing even when the page is perfectly fine. That failure looks identical to a missing edit and is worth at least one wasted debugging round. Documented alongside the alternative: build first and grep `docs/.vitepress/dist/` for static HTML.

Also recorded that `Failed to resolve dependency: debug, present in 'optimizeDeps.include'` on startup is expected and harmless, and added the concrete `grep -o 'id="[^"]*"'` command for checking anchor fragments, which the build does not validate.

## Verification

Both claims were verified live, not assumed — the dev server was started, the port fallback observed, the SPA shell confirmed by curl, and the rendered content confirmed through an actual browser.

`npm run docs:build` passes. No content under `docs/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)