### PR TITLE
docs: layout-data and upload failures, plus a command table fix

### DIFF
--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -37,7 +37,7 @@ graph TD
 
 1. Process images — Resizes to thumbnail and optionally produces a blurred variant for sensitive content. Details in [Sheet blurring](/guide/concepts/sheet-blurring).
 
-1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages.
+1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages. **If any image fails to upload, the app is left alone** rather than being pointed at images that are not there — see [`Failed to upload N of M thumbnail image(s)`](/guide/troubleshooting#failed-to-upload-n-of-m-thumbnail-image-s).
 
 1. Save the app — Once every sheet has been dealt with, the app is saved **once**. See below.
 

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -20,7 +20,7 @@ Filters mirror the exclusion options but use the `--blur-sheet-...` prefix. You 
 Available in QS Cloud and QSEoW:
 
 - `--blur-sheet-number <numbers...>`
-  Blur by position in the app (1 = first sheet). Example: `--blur-sheet-number 1 3 5`.
+  Blur by position in the app (1 = first sheet). Example: `--blur-sheet-number 1 3 5`. Sheet numbers come from the sheets' display order — see [How sheet numbers are decided](/guide/concepts/sheet-exclusion#how-sheet-numbers-are-decided).
 - `--blur-sheet-title <titles...>`
   Blur by exact sheet title. Titles with spaces must be quoted.
 - `--blur-sheet-status <status...>`

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -13,7 +13,7 @@ Exclude sheets when creating thumbnails to keep special-purpose sheets unchanged
 Available in both QS Cloud and QSEoW:
 
 - --exclude-sheet-number <numbers...>
-  Exclude by position in the app (1 = first sheet).
+  Exclude by position in the app (1 = first sheet). See [How sheet numbers are decided](#how-sheet-numbers-are-decided).
 - --exclude-sheet-title <titles...>
   Exclude by exact sheet title. Titles with spaces must be quoted.
 - --exclude-sheet-status <status...>
@@ -33,6 +33,20 @@ Example parameters usage:
 ```
 
 Tip: Titles with spaces must be wrapped in quotes.
+
+## How sheet numbers are decided
+
+`--exclude-sheet-number` and `--blur-sheet-number` refer to a sheet's position in the app, where 1 is the first sheet. That position comes from the sheets' display order in Qlik Sense, which Butler Sheet Icons reads from the engine before doing anything else.
+
+::: warning Numbering can shift in apps with an incomplete sheet — BSI 3.12.0 or later
+A sheet missing its layout data has no usable position, so it is placed **at the end** of the sheet list. In an app containing such a sheet, numbering can therefore differ from what you might expect.
+
+In practice there is nothing to migrate: before BSI 3.12.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
+
+Apps whose sheets all have complete layout data are numbered exactly as before.
+:::
+
+If you rely on sheet numbers, check them in the log of a successful run before trusting them — Butler Sheet Icons names each sheet by number, title and ID as it processes it.
 
 ## Excluding sheets based on the sheet's status
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -93,6 +93,66 @@ In earlier versions this printed `Connection to tenant … successful.` followed
 
 **What to do:** verify `--tenanturl` points at a Qlik Sense Cloud tenant and that `--apikey` is valid and unexpired. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
 
+### `Failed to upload N of M thumbnail image(s)`
+
+Thumbnail images were generated but could not be uploaded, so **the app was left untouched** and its sheets keep the icons they already had.
+
+On Qlik Sense Cloud:
+
+```
+CLOUD APP (stack): CloudError: Failed to upload 2 of 5 thumbnail image(s) to Qlik Sense Cloud app abc-123
+```
+
+On Qlik Sense Enterprise on Windows the message names the content library instead:
+
+```
+QSEOW: qseowProcessApp (stack): QseowError: Failed to upload 2 of 5 thumbnail image(s) to content library BSI thumbnails
+```
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions the run carried on after a failed upload and repointed **every** sheet at an image that was not there, replacing working icons with broken ones — and reported no error. If apps are showing broken sheet icons from an earlier run, see "Repairing apps affected before upgrading" below.
+:::
+
+**What to do:**
+
+1. **Your sheets are safe.** Nothing in the app was changed, so its existing icons are intact. There is no cleanup to do.
+2. **Read the lines immediately above**, prefixed `CLOUD UPLOAD 1` or `QSEOW UPLOAD 1`. Those name the underlying reason — that is where the actual cause is. Common ones are an image larger than the tenant or server accepts, a content library that does not exist or that the account cannot write to, and network interruptions.
+3. **Fix the cause and re-run.** The command is safe to run again.
+
+Every image is attempted before the run stops, so one failure does not hide the others — the count tells you how widespread the problem is.
+
+#### Repairing apps affected before upgrading
+
+If earlier runs left apps showing broken sheet icons, re-running `create-sheet-thumbnails` against those apps repairs them, once the upload problem itself is resolved. To clear the icons instead of regenerating them, use `qscloud remove-sheet-icons` — note this exists only for Qlik Sense Cloud.
+
+### `TypeError: Cannot read properties of undefined (reading 'rank')`
+
+A single sheet missing its layout data caused the **whole app** to be abandoned before any thumbnail was created or removed. Every other sheet in that app was left untouched.
+
+::: warning Requires BSI 3.12.0 or later
+Fixed. Such sheets are now sorted to the end of the sheet list and processed like any other, so the app completes.
+:::
+
+Search your logs for `reading 'rank'` — that phrase is identical in every case. The text before it varies by platform and by how far the run had got:
+
+| Platform | Stage | Log line begins |
+| --- | --- | --- |
+| Qlik Sense Cloud | Creating thumbnails | `CLOUD APP (stack):` |
+| Qlik Sense Cloud | Applying thumbnails to sheets | `CLOUD UPDATE SHEETS (stack):` |
+| Qlik Sense Cloud | Removing sheet icons | `CLOUD REMOVE SHEET ICONS 1 (stack):` |
+| Enterprise on Windows | Creating thumbnails | `QSEOW: qseowProcessApp (stack):` |
+| Enterprise on Windows | Applying thumbnails to sheets | `QSEOW UPDATE SHEETS (stack):` |
+
+A closely related failure, `reading 'showCondition'`, is fixed by the same change and is worth searching for too. It struck slightly later — after thumbnails had been generated but before they were uploaded, so the work was still discarded.
+
+**What to do:** upgrade and re-run. The affected apps should now complete.
+
+**What causes it:** the sheet is missing its layout data — the part carrying its position in the app and its show condition. This comes from Qlik Sense rather than Butler Sheet Icons, and is uncommon. It has been seen with sheets that are partially created or partially deleted, and with sheets whose owner no longer exists. Such a sheet is now named in the log as it is processed, so you can still find it in Qlik Sense to repair or delete it.
+
+**One consequence to be aware of:** sheet numbers come from this sort order, so in an app containing such a sheet the numbering can differ from before — see [Sheet exclusion](/guide/concepts/sheet-exclusion) and [Sheet blurring](/guide/concepts/sheet-blurring).
+
+**Not covered by this fix:** a sheet missing its **title and description** — a different part of the sheet record — can still interrupt a run. That case is less common and is being addressed separately.
+
 ### The run failed — has anything changed in Qlik Sense?
 
 An app is saved once, after all of its sheets have been dealt with. If the run fails before that save, **nothing about the app changes** and its sheets keep the icons they had. Re-running is a clean retry, not a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -14,19 +14,21 @@ butler-sheet-icons <platform> <command> [options]
 
 ## Quick Reference
 
-| Platform  | Command                   | Purpose                              |
-| --------- | ------------------------- | ------------------------------------ |
-| `qscloud` | `create-sheet-icons`      | Create thumbnails for QS Cloud apps  |
-| `qscloud` | `remove-sheet-icons`      | Remove thumbnails from QS Cloud apps |
-| `qscloud` | `list-collections`        | List available collections           |
-| `qseow`   | `create-sheet-thumbnails` | Create thumbnails for QSEoW apps     |
-| `qseow`   | `create-sheet-icons`      | Alias of create-sheet-thumbnails     |
-| `qseow`   | `remove-sheet-icons`      | Remove thumbnails from QSEoW apps    |
-| `browser` | `install`                 | Install browser for BSI              |
-| `browser` | `list-installed`          | Show installed browsers              |
-| `browser` | `list-available`          | Show available browsers for download |
-| `browser` | `uninstall`               | Remove specific browser              |
-| `browser` | `uninstall-all`           | Remove all browsers                  |
+| Platform  | Command                   | Purpose                              | Alias                     |
+| --------- | ------------------------- | ------------------------------------ | ------------------------- |
+| `qscloud` | `create-sheet-thumbnails` | Create thumbnails for QS Cloud apps  | `create-sheet-icons`      |
+| `qscloud` | `remove-sheet-icons`      | Remove thumbnails from QS Cloud apps | `remove-sheet-thumbnails` |
+| `qscloud` | `list-collections`        | List available collections           | —                         |
+| `qseow`   | `create-sheet-thumbnails` | Create thumbnails for QSEoW apps     | `create-sheet-icons`      |
+| `browser` | `install`                 | Install browser for BSI              | —                         |
+| `browser` | `list-installed`          | Show installed browsers              | —                         |
+| `browser` | `list-available`          | Show available browsers for download | —                         |
+| `browser` | `uninstall`               | Remove specific browser              | —                         |
+| `browser` | `uninstall-all`           | Remove all browsers                  | —                         |
+
+::: warning No `remove-sheet-icons` on QSEoW
+Removing sheet icons is available for Qlik Sense Cloud only. There is no `qseow remove-sheet-icons` command — `create-sheet-thumbnails` is the only `qseow` command.
+:::
 
 ## Global Options
 


### PR DESCRIPTION
Publishes two drafts from the butler-sheet-icons repo, together because both land on pages the exit-code work just touched:

- `one-bad-sheet-no-longer-fails-the-app.md`
- `failed-uploads-no-longer-break-sheet-icons.md`

Targets `next` — both document BSI 3.12.0.

## ⚠️ Found while verifying: a live error on the production site

The `qseow remove-sheet-icons` row in the command table **documents a command that does not exist.**

`qseow` registers exactly one subcommand — `create-sheet-thumbnails`, with the alias `create-sheet-icons` (`src/lib/commands/qseow/index.js:37`). Removing sheet icons is Qlik Sense Cloud only. A QSEoW administrator following that table gets an "unknown command" error.

The draft asserted this in passing and I disbelieved it, since the file `src/lib/qseow/qseow-remove-sheet-icons.js` exists — but that is internal helper code with no command wired to it. The draft was right.

The table now lists the real command surface with actual aliases, several of which were undocumented (`qscloud remove-sheet-thumbnails`, and `create-sheet-icons` as an alias rather than the primary name), plus a callout stating there is no QSEoW removal command.

**This fix reaches production only at the next release merge.** If you would rather correct it sooner, that is a `main` hotfix — say the word.

## Per page

| Page | Change | What went in |
|---|---|---|
| `/guide/troubleshooting` | Edited | Entries for `Failed to upload N of M thumbnail image(s)` and `TypeError: … reading 'rank'`, each symptom → cause → fix, plus how to repair apps left showing broken icons by a pre-3.12.0 run |
| `/reference/commands` | Edited | Command table corrected; aliases documented; callout that QSEoW has no removal command |
| `/guide/concepts/sheet-exclusion` | Edited | New "How sheet numbers are decided" — sheets with no usable rank now sort to the end, which can shift numbering |
| `/guide/concepts/sheet-blurring` | Edited | Cross-link to that section |
| `/guide/concepts/how-it-works` | Edited | The upload step now leaves the app untouched on failure |

## Verified against the implementation

| Claim | Source |
|---|---|
| Sheets with no usable rank sort last | `src/lib/util/sheet-list.js:102` `sortSheetsByRank` |
| `TypeError: Cannot read properties of undefined (reading 'rank')` | `sheet-list.js:84` — quoted verbatim in the source |
| Sheet numbers derive from that sort order | `sheet-list.js:55` |
| `Failed to upload N of M thumbnail image(s) to Qlik Sense Cloud app <id>` | `src/lib/cloud/cloud-upload.js:148` |
| `… to content library <name>` | `src/lib/qseow/qseow-upload.js:131` |
| `CLOUD UPLOAD 1` / `QSEOW UPLOAD 1` prefixes | `cloud-upload.js:119`, `qseow-upload.js:102` |
| Every image attempted before stopping | `failedCount + uploadedCount` covers the whole set |
| No `qseow remove-sheet-icons` | `src/lib/commands/qseow/index.js:34-38` |

All draft claims held. The only correction was to the **site**, not the drafts.

## Verification

`npm run docs:build` passes. All three new anchor fragments checked against the generated HTML — `#failed-to-upload-n-of-m-thumbnail-image-s`, `#typeerror-cannot-read-properties-of-undefined-reading-rank`, `#how-sheet-numbers-are-decided`. All resolve, which was worth checking given the backticks, parentheses and apostrophes in those headings.

Preview: https://docs-sheet-layout-and-uploa.butler-sheet-icons-docs.pages.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)