### PR TITLE
docs: next is now the default branch, so drop the template exception

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,10 +152,12 @@ This site is **not** deployed via GitHub Pages. There is no `gh-pages` branch in
 
 ### Branch Model
 
-**All work goes to `next`.** Branch off `next`, PR into `next`. There is no per-change branch decision.
+**All work goes to `next`.** Branch off `next`, PR into `next`. There is no per-change branch decision and no exception — `.github/` templates and workflows included.
 
-- `next` — where all documentation work goes. Preview URL only.
+- `next` — the repository's **default branch**, and where all documentation work goes. A fresh clone or worktree already starts here. Preview URL only.
 - `main` — production, what the public site serves. Reached only by merging `next` at BSI release time.
+
+A repository ruleset covers both branches: pull requests are required, direct and force pushes rejected, no approvals needed.
 
 The site is single-version — one copy of the docs, no per-release archive — so anything on `main` is presented as documentation for the current BSI release whatever it actually describes, and Cloudflare publishes it within minutes. Routing everything through `next` keeps unreleased documentation off the public site. Writing to `main` directly is a deliberate production hotfix, not a normal option.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,9 @@ published at <https://butler-sheet-icons.ptarmiganlabs.com>.
 
 ## Branch rule
 
-**All work goes to `next`.** Branch off an up-to-date `next`, PR into `next`.
+**All work goes to `next`.** It is the repository's default branch, so a fresh clone or worktree
+already starts there. Branch off an up-to-date `next`, PR into `next`. There are no exceptions —
+`.github/` templates and workflows included.
 
 `main` is production — it is what the public site serves, and Cloudflare Pages publishes it
 automatically within minutes of a merge. It is reached only by merging `next` at BSI release time,
@@ -14,13 +16,15 @@ which is a separate maintenance step documented in [README_DEPLOY.md](./README_D
 Writing to `main` directly is a deliberate production hotfix, not a normal option. Do not choose
 it without being asked to.
 
-One narrow exception: GitHub reads the pull request template and the issue templates under
-`.github/` **only from the default branch**, so a change to those has no effect until it is on
-`main` and targets `main` directly. This does not extend to anything under `docs/` — that is site
-content and always goes to `next`.
+**Check your starting point before your first edit**, not before your first commit — editing a tree
+that predates `next` produces content that duplicates or contradicts what is already there:
 
-A repository ruleset requires a pull request for `main` and rejects direct and force pushes. No
-approvals are required.
+```bash
+git fetch origin && git merge-base --is-ancestor origin/next HEAD || git rebase origin/next
+```
+
+A repository ruleset covers both `main` and `next`: pull requests are required, and direct and
+force pushes are rejected. No approvals are required, so you can merge your own once checks pass.
 
 ## Where new documentation comes from
 

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -42,9 +42,11 @@ Two long-lived branches.
 ### Which branch does my change go to?
 
 **`next`. Always.** Branch off an up-to-date `next`, PR into `next`. There is no decision
-to make.
+to make, and no exception — `.github/` templates and workflows included.
 
-`main` is reached only by merging `next` at release time, per the procedure below.
+`next` is the repository's **default branch**, so a fresh clone or worktree already starts
+there, GitHub reads the pull request and issue templates from it, and Dependabot targets
+it. `main` is reached only by merging `next` at release time, per the procedure below.
 
 The site is single-version: there is exactly one copy of the docs and no per-release
 archive. So content merged to `main` is presented as documentation for the current
@@ -57,11 +59,16 @@ The cost is that a correction to an already-live page waits for the next release
 If something on production genuinely cannot wait, that is a deliberate hotfix branched
 off `main` — an exception, not one of two normal options.
 
-There is one other narrow exception. GitHub reads a few repository files **only from the
-default branch**, `main` — the pull request template and the issue templates under
-`.github/`. A fix to those has no effect until it is on `main`, so it targets `main`
-directly. This does not extend to anything under `docs/`, which is site content and
-always goes to `next`.
+A repository ruleset covers **both** `main` and `next`: pull requests are required, and
+direct and force pushes are rejected. No approvals are required, so you can merge your own
+once checks pass.
+
+> [!WARNING]
+> **If you ever change the default branch again**, check the ruleset first. It lists
+> `refs/heads/main` and `refs/heads/next` explicitly, but also carries the symbolic
+> `~DEFAULT_BRANCH`, which **follows** whichever branch is default. Relying on that alone
+> silently unprotects the branch you just demoted — which is exactly what happened when
+> `next` was made default. Keep the explicit refs.
 
 ### At release time
 


### PR DESCRIPTION
Follows the switch of the default branch to `next`. Three files asserted things that are now false.

## The template exception is gone, not corrected

`CLAUDE.md` and `README_DEPLOY.md` both said GitHub reads the pull request and issue templates "only from the default branch, `main`", and that fixes to them therefore target `main` directly.

That is now backwards. The default branch is `next`, the template is already there, and templates follow the normal rule like everything else. **Deleted rather than reworded** — the branch model has one fewer special case than it did this morning.

## `~DEFAULT_BRANCH` silently unprotected `main`

Worth recording because it is not obvious. The ruleset targeted `["~DEFAULT_BRANCH", "refs/heads/next"]`. `~DEFAULT_BRANCH` **follows** whichever branch is default, so promoting `next` pointed both conditions at the same branch and left production with no protection at all — no PR requirement, no force-push block, no deletion block.

Now fixed with explicit refs for both branches, and `README_DEPLOY.md` carries a warning against reintroducing the symbolic form.

## Starting point check stays

A fresh clone or worktree now starts on `next`, which removes the common case. `CLAUDE.md` keeps an explicit check anyway, since a branch can be created plenty of other ways:

```bash
git fetch origin && git merge-base --is-ancestor origin/next HEAD || git rebase origin/next
```

Deliberately placed **before the first edit**, not before the first commit. Editing a tree that predates `next` is the actual damage — it produces content that duplicates or contradicts what is already there, and a pre-commit check catches it far too late. This came out of watching a session start work against a `main`-based worktree that was missing the sheet-numbering section it needed to cross-reference.

## Also

- Noted that Dependabot now targets `next`.
- `.github/copilot-instructions.md` branch section brought in line.
- One self-inflicted fix: I first wrote the ruleset warning as a VitePress `::: warning` container, which would have rendered literally since `README_DEPLOY.md` is not part of the site build. Now a GitHub alert, matching the rest of that file.

## Verification

`npm run docs:build` passes. No content under `docs/` changed. Swept all five instruction files for remaining claims that `main` is the default branch, and for leftover exception wording — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)