### PR TITLE
docs: state one correct range and default for --blur-factor

### DIFF
--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -41,16 +41,29 @@ In earlier versions `--blur-sheet-number` blurred sheets you had not selected �
 
 Control blur strength with `--blur-factor <factor>`.
 
-- Range: 0 = no blur … 1000 = full blur.
-- CLI help shows default: 10. Choose a value that balances privacy with recognizability.
+- **Range: 1–100.** 1 is the lightest blur, 100 the heaviest.
+- **Default: 5.** Choose a value that balances privacy with recognizability.
+
+Two things are worth knowing before you pick a value:
+
+- **A value above 100 is accepted but capped at 100.** `--blur-factor 1000` runs without an error or a warning and produces exactly the same image as `--blur-factor 100`.
+- **`--blur-factor 0` does not mean "no blur".** Values below 1 are treated as 1, so the lightest blur you can ask for is 1. To leave a sheet unblurred, do not select it with any of the `--blur-sheet-...` filters.
+
+A value that is not a non-negative whole number is rejected before Butler Sheet Icons connects to Qlik Sense:
+
+```
+error: option '--blur-factor <factor>' argument 'abc' is invalid. Blur factor must be a non-negative integer.
+```
 
 ### Blur effect examples
 
+The first row is the unmodified thumbnail, shown for comparison — it is not a `--blur-factor` value.
+
 | Blur Factor | Result                                                           |
 | ----------- | ---------------------------------------------------------------- |
-| 0           | ![No blur](/images/blur-factor-0.png "No blur applied")          |
-| 5           | ![Light blur](/images/blur-factor-5.png "Light blur applied")    |
-| 10          | ![Medium blur](/images/blur-factor-10.png "Medium blur applied") |
+| Not blurred | ![Unblurred sheet thumbnail](/images/blur-factor-0.png "Thumbnail with no blur applied") |
+| 5           | ![Sheet thumbnail with light blur](/images/blur-factor-5.png "Light blur applied")    |
+| 10          | ![Sheet thumbnail with medium blur](/images/blur-factor-10.png "Medium blur applied") |
 
 ## Examples
 

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -56,7 +56,7 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--blur-sheet-number` | `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` | Blur by position        |         | `--blur-sheet-number 2 4`             |
 | `--blur-sheet-title`  | `BSI_QSCLOUD_CST_BLUR_SHEET_TITLE`  | Blur by title           |         | `--blur-sheet-title "Financial Data"` |
 | `--blur-sheet-status` | `BSI_QSCLOUD_CST_BLUR_SHEET_STATUS` | Blur by status          | `[]`    | `--blur-sheet-status published`       |
-| `--blur-factor`       | `BSI_QSCLOUD_CST_BLUR_FACTOR`       | Blur intensity (0-1000) | `5`     | `--blur-factor 10`                    |
+| `--blur-factor`       | `BSI_QSCLOUD_CST_BLUR_FACTOR`       | Blur intensity (1-100)  | `5`     | `--blur-factor 10`                    |
 
 ::: tip One sheet number per environment variable
 `BSI_QSCLOUD_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -76,7 +76,7 @@ butler-sheet-icons qseow create-sheet-thumbnails [options]
 | `--blur-sheet-title`  | `BSI_QSEOW_CST_BLUR_SHEET_TITLE`  | Blur by title          |         | `--blur-sheet-title "Financial Data"` |
 | `--blur-sheet-status` | `BSI_QSEOW_CST_BLUR_SHEET_STATUS` | Blur by status         | `[]`    | `--blur-sheet-status published`       |
 | `--blur-sheet-tag`    | `BSI_QSEOW_CST_BLUR_SHEET_TAG`    | Blur by tag            |         | `--blur-sheet-tag "sensitive"`        |
-| `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (0-100) | `5`     | `--blur-factor 10`                    |
+| `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (1-100) | `5`     | `--blur-factor 10`                    |
 
 ::: tip One sheet number per environment variable
 `BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSEOW_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:


### PR DESCRIPTION
## Description

Fixes #43. The site gave **three different ranges** for `--blur-factor` and **two different defaults**, so a reader had no way to tell which was right:

| Where | Range said | Default said |
| --- | --- | --- |
| `/guide/concepts/sheet-blurring` | 0–1000 | 10 |
| `/reference/qscloud` | 0-1000 | 5 |
| `/reference/qseow` | 0-100 | 5 |

Verified against the implementation: both option declarations use `.default('5')`, and both consumers (`qseow-process-app.js`, `cloud/sheet-screenshot.js`) clamp to `1..100` before handing the value to Jimp. So the effective range is **1–100** and the default is **5**. All three places now say that.

Two consequences were undocumented and are now stated on the blurring page:

- **A value above 100 is accepted and silently capped.** `parsePositiveInteger` is called with no `max`, so `--blur-factor 1000` runs without error or warning and produces the same image as `--blur-factor 100`. This is what made the `0-1000` claim actively harmful rather than merely untidy — a reader who followed it got no feedback that the value did nothing.
- **`--blur-factor 0` is not "no blur".** Values below 1 clamp to 1. The blur effect table no longer presents `0` as a factor value; the first row is now labelled as the unmodified thumbnail shown for comparison.

The rejection message quoted on the page was captured verbatim by executing the real command builder, not inferred from the sibling option.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

| Page | What changed |
| --- | --- |
| `/guide/concepts/sheet-blurring` | Corrected range and default; added the capping and the `0` behaviour; relabelled the first row of the blur effect table; descriptive alt text on all three images |
| `/reference/qscloud` | `Blur intensity (0-1000)` → `(1-100)` |
| `/reference/qseow` | `Blur intensity (0-100)` → `(1-100)` so both reference tables and the concept page agree |

## Checklist

- [x] This PR targets `next`
- [x] `npm run docs:build` passes locally (the build fails on dead internal links)
- [x] Internal links are absolute and extensionless — n/a, no links added
- [x] New pages have a sidebar entry in `docs/.vitepress/config.js` — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — alt text improved; the three existing images are unchanged
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Notes for reviewers

**`/reference/qseow` was already correct** at `0-100` and the issue said to leave it. I changed it to `1-100` anyway so the two reference tables and the concept page state the same effective range — issue #43's last acceptance criterion asks for exactly that. Flagging it because it is the one edit that goes beyond "fix what was wrong".

**Not fixed here — the upstream mismatch.** The CLI help text still reads `Factor to blur the sheets with. 0 = no blur, 100 = full blur.`, which contradicts the clamp of 0 → 1. That is a `butler-sheet-icons` bug, not a doc site one, and #43 is deliberately scoped around it. If it is fixed upstream, the "`--blur-factor 0` does not mean no blur" bullet here should be revisited.

**Unrelated, but urgent before `next` → `main`:** BSI shipped as **4.0.0**, not 3.12.0 — release-please recomputed the bump to a major after two breaking changes landed in PR #774. There are 17 `3.12.0` references across 8 pages on `next`, all now wrong. Nothing is live and wrong since `next` is preview-only, but they must be corrected before `next` is merged. Not touched in this PR.
