### PR TITLE
docs: correct the version gates from 3.12.0 to 4.0.0

### DIFF
--- a/docs/guide/advanced/ci-cd.md
+++ b/docs/guide/advanced/ci-cd.md
@@ -146,11 +146,11 @@ export https_proxy='http://username:password@proxy.example.com:port'
 
 ## Exit codes and job status
 
-::: danger Action may be required — requires BSI 3.12.0 or later
+::: danger Action may be required — requires BSI 4.0.0 or later
 This change can turn a scheduled job that always reported success into one that reports failure. That is intended, but read this before upgrading so it does not surprise you at 3am.
 :::
 
-Until BSI 3.12.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
+Until BSI 4.0.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
 
 BSI now exits `1` when the run failed or completed with apps it could not process. See [Exit codes](/reference/commands#exit-codes) for exactly what counts as a failure.
 

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -69,8 +69,8 @@ With `--browser-version latest`, BSI does **not** check whether a newer browser 
 If several builds of the same browser are cached, do not rely on which one gets picked. Pin `--browser-version` to an exact build ID whenever the exact version matters.
 :::
 
-::: warning Requires BSI 3.12.0 or later
-In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 3.12.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
+::: warning Requires BSI 4.0.0 or later
+In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 4.0.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
 :::
 
 ### 3. Download browser (lowest priority)
@@ -113,8 +113,8 @@ Run `browser install` once while the machine still has internet access. The brow
 Setting `PUPPETEER_EXECUTABLE_PATH` to a browser installed by other means works too, and is the usual approach for Docker and centrally managed environments. See [Strategy 2](#strategy-2-use-a-system-browser-via-puppeteer-executable-path-controlled) and [Strategy 3](#strategy-3-use-a-pre-cached-browser-semi-offline) below.
 :::
 
-::: warning Requires BSI 3.12.0 or later
-Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 3.12.0 the messages above are shown instead.
+::: warning Requires BSI 4.0.0 or later
+Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 4.0.0 the messages above are shown instead.
 :::
 
 ## Key environment variables

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -35,7 +35,7 @@ When running Butler Sheet Icons for the first time, you have several options. Th
 
 ### Automatic Download (Default)
 
-If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed). From BSI 3.12.0 the download happens only once — later runs find the browser in the cache and reuse it, needing no download and no internet access for the browser itself. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority) for the exact matching rules.
+If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed). From BSI 4.0.0 the download happens only once — later runs find the browser in the cache and reuse it, needing no download and no internet access for the browser itself. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority) for the exact matching rules.
 
 ::: code-group
 

--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -43,7 +43,7 @@ graph TD
 
 ### When the app is saved
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions saved the app once per sheet.
 :::
 

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -31,7 +31,7 @@ QSEoW only:
 - `--blur-sheet-tag <value...>`
   Blur sheets that have one or more specified tags (set in QMC > App objects). Tags don’t exist for individual sheets in QS Cloud.
 
-::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+::: warning Sheet numbers were matched incorrectly before BSI 4.0.0
 In earlier versions `--blur-sheet-number` blurred sheets you had not selected — only the last number you listed was used, and it was matched as a text fragment rather than as a whole sheet number. `--blur-sheet-number 12` also blurred sheets 1 and 2.
 
 `--blur-sheet-title`, `--blur-sheet-status` and `--blur-sheet-tag` were not affected. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers) for the full description, and [Sheets you did not select were skipped or blurred](/guide/troubleshooting#sheets-you-did-not-select-were-skipped-or-blurred) for what to check and re-run.

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -38,10 +38,10 @@ Tip: Titles with spaces must be wrapped in quotes.
 
 `--exclude-sheet-number` and `--blur-sheet-number` refer to a sheet's position in the app, where 1 is the first sheet. That position comes from the sheets' display order in Qlik Sense, which Butler Sheet Icons reads from the engine before doing anything else.
 
-::: warning Numbering can shift in apps with an incomplete sheet — BSI 3.12.0 or later
+::: warning Numbering can shift in apps with an incomplete sheet — BSI 4.0.0 or later
 A sheet missing its layout data has no usable position, so it is placed **at the end** of the sheet list. In an app containing such a sheet, numbering can therefore differ from what you might expect.
 
-In practice there is nothing to migrate: before BSI 3.12.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
+In practice there is nothing to migrate: before BSI 4.0.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
 
 Apps whose sheets all have complete layout data are numbered exactly as before.
 :::
@@ -65,7 +65,7 @@ error: option '--exclude-sheet-number <number...>' argument 'abc' is invalid. Ex
 
 Each of these two options can also be set through an environment variable, but a variable holds **one** sheet number only — see [QSEoW reference](/reference/qseow#sheet-filtering) and [QS Cloud reference](/reference/qscloud#sheet-filtering). To select several sheets, use the command-line option.
 
-::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+::: warning Sheet numbers were matched incorrectly before BSI 4.0.0
 In earlier versions `--exclude-sheet-number` and `--blur-sheet-number` selected the wrong sheets. Two faults combined:
 
 - **Only the last number you listed was used.** `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`, so sheet 3 was processed as normal.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -33,7 +33,7 @@ butler-sheet-icons browser list-installed
 
 ## Run Failures and Exit Codes
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions always exited with `0`. If your automation never reported a failure before upgrading, that is why — see [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status).
 :::
 
@@ -109,7 +109,7 @@ On Qlik Sense Enterprise on Windows the message names the content library instea
 QSEOW: qseowProcessApp (stack): QseowError: Failed to upload 2 of 5 thumbnail image(s) to content library BSI thumbnails
 ```
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 In earlier versions the run carried on after a failed upload and repointed **every** sheet at an image that was not there, replacing working icons with broken ones — and reported no error. If apps are showing broken sheet icons from an earlier run, see "Repairing apps affected before upgrading" below.
 :::
 
@@ -129,7 +129,7 @@ If earlier runs left apps showing broken sheet icons, re-running `create-sheet-t
 
 A single sheet missing its layout data caused the **whole app** to be abandoned before any thumbnail was created or removed. Every other sheet in that app was left untouched.
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Fixed. Such sheets are now sorted to the end of the sheet list and processed like any other, so the app completes.
 :::
 
@@ -404,7 +404,7 @@ Browser-related problems are among the most common issues when using Butler Shee
 
 - `browser list-available` reports that `versionhistory.googleapis.com` could not be reached
 - `browser install` reports that the requested version "cannot be downloaded"
-- On BSI versions before 3.12.0, `browser list-available` instead printed a raw stack trace such as `TypeError: Cannot read properties of undefined (reading 'status')`, with line numbers from inside the BSI binary
+- On BSI versions before 4.0.0, `browser list-available` instead printed a raw stack trace such as `TypeError: Cannot read properties of undefined (reading 'status')`, with line numbers from inside the BSI binary
 
 **Cause:**
 
@@ -851,7 +851,7 @@ export http_proxy=http://user:pass@proxy.company.com:8080
 
 **Cause:**
 
-Butler Sheet Icons before 3.12.0 read these two options incorrectly, in two ways at once:
+Butler Sheet Icons before 4.0.0 read these two options incorrectly, in two ways at once:
 
 - Only the last number you listed was used. `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`.
 - That number was then matched as a text fragment rather than as a whole sheet number, so `--exclude-sheet-number 12` also excluded sheets 1 and 2.
@@ -876,7 +876,7 @@ Blurred sheet thumbnail (via sheet number): 1: 'Sales overview', ...
 
 **Solutions:**
 
-1. **Upgrade to BSI 3.12.0 or later.** Both options now keep every number you list and match each as a whole sheet number.
+1. **Upgrade to BSI 4.0.0 or later.** Both options now keep every number you list and match each as a whole sheet number.
 
 2. **Re-check your options before re-running.** If you worked around the old behaviour — listing sheet numbers one run at a time, or picking numbers that avoided the overlap — those workarounds are no longer needed and will now produce the wrong result.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -51,7 +51,7 @@ These options are available for most commands:
 
 ## Exit codes
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions always exited with `0`, whatever happened during the run.
 :::
 


### PR DESCRIPTION
## Description

Every `Requires BSI 3.12.0` gate on the site named a version that does not exist.

The drafts these pages came from were written while the open release-please PR (ptarmiganlabs/butler-sheet-icons#774) was titled `chore(main): release butler-sheet-icons 3.12.0`, so 3.12.0 was the expected next version. Two breaking changes landed before it merged — the removal of `--browser firefox` from the thumbnail commands, and the exit code change — so release-please recomputed the bump as a major. It shipped as **4.0.0** (`butler-sheet-icons-v4.0.0`, published 2026-08-09). There is no 3.12.0.

19 occurrences across 8 pages, accumulated over several separate publishing passes. All are gates for behaviour that is in 4.0.0, and every phrasing takes the substitution unchanged — `Requires BSI X or later`, `before BSI X`, `Until BSI X`, `From BSI X`.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

`/guide/troubleshooting` (6), `/guide/concepts/browser-detection-and-environment-variables` (4), `/guide/concepts/sheet-exclusion` (3), `/guide/advanced/ci-cd` (2), `/guide/concepts/how-it-works` (1), `/guide/concepts/sheet-blurring` (1), `/guide/concepts/browser-management` (1), `/reference/commands` (1).

## Checklist

- [x] This PR targets `next`
- [x] `npm run docs:build` passes locally (the build fails on dead internal links)
- [x] Internal links are absolute and extensionless — n/a, no links changed
- [x] New pages have a sidebar entry in `docs/.vitepress/config.js` — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Notes for reviewers

The `3.11.0` in the sample crash report on `/guide/advanced/crash-dumps` is deliberately left alone — that is illustrative output showing what a crash report looks like, not a version gate.

> [!WARNING]
> **This PR does not make `next` safe to publish to `main` on its own.**
>
> 4.0.0 removed `--browser firefox` from `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`, and it now fails at argument parsing. The site still instructs readers to use it in roughly ten places across `/guide/troubleshooting`, `/guide/concepts/browser-management`, `/guide/configuration/qseow`, `/guide/configuration/qlik-sense-cloud`, `/guide/concepts/browser-detection-and-environment-variables` and `/examples/browser-management`.
>
> The draft that documents this, `browser-version-selection.md`, is still pending approval in the BSI staging folder and unpublished. Publishing `next` to `main` before that is handled would put breaking, actively wrong instructions on the production site.
