### PR TITLE
docs: stop offering Firefox for thumbnail commands

### DIFF
--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -157,7 +157,7 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 :::
 
-### Specify browser type (Chrome/Firefox)
+### Specify browser type
 
 ::: code-group
 
@@ -183,7 +183,7 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 :::
 
-Using Firefox works the same, set `--browser firefox`.
+`chrome` is the only value the thumbnail commands accept. Firefox can be installed and removed with the `browser` commands, but cannot render thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Use a specific browser version
 
@@ -233,10 +233,10 @@ Browsers in Docker are downloaded inside the container.
 # List browsers in container
 docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
 
-# Install Firefox in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser firefox
+# Install a specific Chrome build in container
+docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
 
-# Use Firefox for sheet icons
+# Use that build for sheet icons
 docker run -it --rm \
   -v $(pwd)/images:/nodeapp/img \
   ptarmiganlabs/butler-sheet-icons:latest \
@@ -246,7 +246,8 @@ docker run -it --rm \
   --logonuserid user@company.com \
   --logonpwd mypassword \
   --appid 12345678-1234-1234-1234-123456789012 \
-  --browser firefox \
+  --browser chrome \
+  --browser-version 121.0.6167.85 \
   --headless true
 ```
 
@@ -254,10 +255,10 @@ docker run -it --rm \
 # List browsers in container
 docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
 
-# Install Firefox in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser firefox
+# Install a specific Chrome build in container
+docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
 
-# Use Firefox for sheet icons
+# Use that build for sheet icons
 docker run -it --rm `
   -v ${PWD}/images:/nodeapp/img `
   ptarmiganlabs/butler-sheet-icons:latest `
@@ -267,7 +268,8 @@ docker run -it --rm `
   --logonuserid user@company.com `
   --logonpwd mypassword `
   --appid 12345678-1234-1234-1234-123456789012 `
-  --browser firefox `
+  --browser chrome `
+  --browser-version 121.0.6167.85 `
   --headless true
 ```
 
@@ -397,7 +399,7 @@ docker run -it --rm `
 1. Use visible mode when debugging login issues
 2. Keep multiple browser versions for compatibility testing
 3. Use verbose logging to understand behavior
-4. Test with both Chrome and Firefox
+4. Test against more than one Chrome build before pinning one
 
 ### CI/CD
 

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -56,7 +56,7 @@ If no system browser is configured, BSI looks in the Puppeteer cache directory (
 
 A cached browser is used when it matches **both** of these:
 
-- **Browser type** — the browser asked for with `--browser` (`chrome` or `firefox`).
+- **Browser type** — the browser asked for with `--browser`. The thumbnail commands accept `chrome` only; the `browser` commands also accept `firefox`.
 - **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly that build ID is used. If a different version is cached, BSI treats it as no match and downloads the version you asked for. If `--browser-version` is `latest` (the default), any cached build of the requested browser type is accepted.
 
 When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -14,10 +14,28 @@ In addition to the cached browsers managed by BSI, you can also point BSI at a s
 
 ## Supported Browsers
 
-Butler Sheet Icons supports two major browsers:
+Butler Sheet Icons manages two browsers, but they are not interchangeable:
 
-- **Chrome**: Full version control available, including specific build numbers
-- **Firefox**: Latest version available (specific version control pending)
+- **Chrome**: the only browser that can render sheet thumbnails. Full version control available, including specific build numbers.
+- **Firefox**: can be installed, listed and removed with the `browser` commands, but **cannot be used to create thumbnails**.
+
+::: warning Firefox is not available for thumbnails — BSI 4.0.0 or later
+`--browser firefox` is rejected by `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`:
+
+```
+error: option '--browser <browser>' argument 'firefox' is invalid. Allowed choices are chrome.
+```
+
+The same applies when the value comes from an environment variable:
+
+```
+error: option '--browser <browser>' value 'firefox' from env 'BSI_QSEOW_CST_BROWSER' is invalid. Allowed choices are chrome.
+```
+
+Firefox never actually worked for thumbnail creation — the rendering path drives the browser over the Chrome DevTools Protocol with a Chromium-only argument list — but earlier versions accepted the option and then failed later, in a way that was hard to interpret. It is now rejected up front.
+
+`browser install`, `browser uninstall`, `browser uninstall-all` and `browser list-available` still accept `--browser firefox`.
+:::
 
 ## Browser Cache Location
 
@@ -88,22 +106,16 @@ When running sheet icon creation commands, you can specify which browser to use 
 ::: code-group
 
 ```bash [Bash]
-# Use Chrome (default)
+# Use Chrome (the only browser accepted here, and the default)
 butler-sheet-icons qscloud create-sheet-icons --browser chrome ...
-
-# Use Firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
 
 # Use specific Chrome version
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 ```
 
 ```powershell [PowerShell]
-# Use Chrome (default)
+# Use Chrome (the only browser accepted here, and the default)
 butler-sheet-icons qscloud create-sheet-icons --browser chrome ...
-
-# Use Firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
 
 # Use specific Chrome version
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
@@ -125,7 +137,7 @@ Chrome versions use build numbers (e.g., `121.0.6167.85`). Butler Sheet Icons su
 
 ### Firefox Versions
 
-Firefox currently supports only the latest version. Specific version control is planned for future releases.
+Firefox is managed only by the `browser` commands — it cannot render thumbnails, so its version affects nothing about a thumbnail run. Firefox build ids are channel-prefixed, for example `stable_153.0.3`.
 
 ## Headless vs. Visible Browser
 
@@ -250,23 +262,23 @@ For testing different configurations:
 ::: code-group
 
 ```bash [Bash]
-# Test with Chrome
+# Test a specific Chrome build
 butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 
-# Test with Firefox
-butler-sheet-icons browser install --browser firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+# Test another Chrome build
+butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
 ```
 
 ```powershell [PowerShell]
-# Test with Chrome
+# Test a specific Chrome build
 butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 
-# Test with Firefox
-butler-sheet-icons browser install --browser firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+# Test another Chrome build
+butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
 ```
 
 :::

--- a/docs/guide/configuration/qlik-sense-cloud.md
+++ b/docs/guide/configuration/qlik-sense-cloud.md
@@ -217,8 +217,8 @@ butler-sheet-icons qscloud create-sheet-icons `
 ### Browser Configuration
 
 ```bash
-# Use specific browser
---browser firefox
+# Browser selection (chrome is the only accepted value)
+--browser chrome
 
 # Show browser (for debugging)
 --headless false

--- a/docs/guide/configuration/qseow.md
+++ b/docs/guide/configuration/qseow.md
@@ -333,8 +333,8 @@ BSI can update icons for Public, Published, and Private sheets in both published
 
 ```bash
 # Browser selection
---browser chrome              # or firefox
---browser-version latest      # or specific version
+--browser chrome              # chrome is the only accepted value
+--browser-version recommended # or stable, a channel, or an exact build
 --headless false              # Show browser for debugging
 ```
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -479,8 +479,8 @@ Creating thumbnails itself does not need internet access once a browser is avail
 2. **Browser Selection and Versions**:
 
    ```bash
-   # Try different browser
-   --browser firefox
+   # Thumbnails are rendered with Chrome only
+   --browser chrome
 
    # Use specific stable browser version
    butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
@@ -548,12 +548,8 @@ Creating thumbnails itself does not need internet access once a browser is avail
 3. **Browser Compatibility Testing**:
 
    ```bash
-   # Test with both Chrome and Firefox
-   # Chrome:
+   # Watch the run in a visible browser
    butler-sheet-icons qscloud create-sheet-icons --browser chrome --headless false ...
-
-   # Firefox:
-   butler-sheet-icons qscloud create-sheet-icons --browser firefox --headless false ...
    ```
 
 4. **SSO and Login Page Issues**:
@@ -599,12 +595,14 @@ Creating thumbnails itself does not need internet access once a browser is avail
    butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
    ```
 
-3. **Firefox as Alternative**:
+3. **Try a different Chrome build**:
    ```bash
-   # If Chrome versions have issues, try Firefox
-   butler-sheet-icons browser install --browser firefox
-   butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+   # If one Chrome build has issues, install and use another
+   butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+   butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
    ```
+
+   Firefox is not an alternative here — it cannot render thumbnails. See [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Browser Cache and Permissions
 
@@ -928,8 +926,8 @@ See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-seve
 2. **Browser Settings**:
 
    ```bash
-   # Try different browser
-   --browser firefox
+   # Thumbnails are rendered with Chrome only
+   --browser chrome
 
    # Ensure browser is up to date
    butler-sheet-icons browser install --browser chrome

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -6,7 +6,7 @@ For details on how BSI decides which browser to use at runtime, and how environm
 
 ## Overview
 
-BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The browser command supports Chrome and Firefox across Windows, macOS, and Linux platforms.
+BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The `browser` command manages both Chrome and Firefox across Windows, macOS, and Linux. Note that only Chrome can render sheet thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ## Basic Usage
 
@@ -121,7 +121,7 @@ butler-sheet-icons browser install [options]
 | --------------------------------- | ------------------------------- | -------------------------------------------------------- | -------- | --------------------------------- |
 | `--loglevel, --log-level <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel debug`                |
 | `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install (chrome, firefox)                     | `chrome` | `--browser firefox`               |
-| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Specific version/build ID to install                     | `latest` | `--browser-version 121.0.6167.85` |
+| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Keyword (`recommended`, `stable`), channel, or build ID   | `recommended` | `--browser-version 121.0.6167.85` |
 | `-h, --help`                      | `-`                             | Display help for command                                 | `-`      | `--help`                          |
 
 **Examples:**
@@ -321,11 +321,12 @@ butler-sheet-icons qscloud create-sheet-thumbnails \
   --browser chrome \
   --browser-version 121.0.6167.85
 
-# Use Firefox for QSEoW
+# Pin a different Chrome build for QSEoW
 butler-sheet-icons qseow create-sheet-thumbnails \
   --host sense.company.com \
   --app-id "app-456" \
-  --browser firefox
+  --browser chrome \
+  --browser-version 120.0.6099.109
 ```
 
 ## Browser Cache Location

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -35,8 +35,8 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--browser-page-timeout` | `BSI_BROWSER_PAGE_TIMEOUT`           | Seconds to wait for a page to load                  | `90`     | `--browser-page-timeout 120`      |
 | `--imagedir`             | `BSI_QSCLOUD_CST_IMAGE_DIR`          | Screenshot directory                                | `./img`  | `--imagedir ./screenshots`        |
 | `--includesheetpart`     | `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART` | Screenshot area (1 = content, 2 = +title, 4 = full) | `1`      | `--includesheetpart 2`            |
-| `--browser`              | `BSI_QSCLOUD_CST_BROWSER`            | Browser type                                        | `chrome` | `--browser firefox`               |
-| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser version                                     | `latest` | `--browser-version 121.0.6167.85` |
+| `--browser`              | `BSI_QSCLOUD_CST_BROWSER`            | Browser type (`chrome` only)                        | `chrome` | `--browser chrome`                |
+| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser version                                     | `recommended` | `--browser-version 121.0.6167.85` |
 | `--skip-login`           | `BSI_QSCLOUD_CST_SKIP_LOGIN`         | Skip login page                                     | `false`  | `--skip-login`                    |
 
 ### Sheet Filtering

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -103,7 +103,7 @@ butler-sheet-icons qseow create-sheet-thumbnails \
   --contentlibrary "Butler sheet thumbnails" \
   --sense-version 2024-May \
   --browser chrome \
-  --browser-version latest \
+  --browser-version recommended \
   --secure true \
   --includesheetpart 2 \
   --browser-page-timeout 120 \

--- a/docs/reference/supported-versions.md
+++ b/docs/reference/supported-versions.md
@@ -122,9 +122,9 @@ butler-sheet-icons qscloud create-sheet-icons \
   --browser chrome \
   --browser-version 121.0.6167.85
 
-# Use Firefox (latest only)
-butler-sheet-icons qscloud create-sheet-icons --browser firefox
 ```
+
+Chrome is the only browser accepted by the thumbnail commands — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Browser Management
 


### PR DESCRIPTION
## Description

Blocks the `next` → `main` publish until merged: without it, production would carry instructions that fail outright on BSI 4.0.0.

4.0.0 removed `firefox` from the `--browser` choices on `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails` (`.choices(['chrome'])`). It is now rejected at argument parsing, from the command line and from the environment variable alike:

```
error: option '--browser <browser>' argument 'firefox' is invalid. Allowed choices are chrome.
error: option '--browser <browser>' value 'firefox' from env 'BSI_QSEOW_CST_BROWSER' is invalid. Allowed choices are chrome.
```

Both captured verbatim by executing the real command builders.

Firefox never actually worked for thumbnails — the render path drives the browser over the Chrome DevTools Protocol with a Chromium-only argument list — but it used to be accepted and then fail somewhere an operator could not interpret. The site instructed readers to use it in **nine command examples across seven pages**, and described it as a valid `--browser` value in five more places.

**Firefox is untouched where it still works.** `browser install`, `browser uninstall`, `browser uninstall-all` and `browser list-available` all keep `.choices(['chrome', 'firefox'])`, and every example using them is unchanged.

Also corrects the `--browser-version` default: 4.0.0 uses `recommended`, not `latest`. `latest` is now a deprecated alias for `stable`.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

| Page | What changed |
| --- | --- |
| `/guide/concepts/browser-management` | Rewrote "Supported Browsers" to separate what each browser can do; added a warning with both verbatim rejection messages; replaced 4 Firefox thumbnail examples; corrected "Firefox Versions" |
| `/guide/troubleshooting` | Replaced 4 Firefox suggestions, including the "Firefox as Alternative" remedy, which is no longer a remedy |
| `/examples/browser-management` | Replaced the Docker Firefox examples and the "Chrome/Firefox" section heading |
| `/reference/browser` | Replaced the QSEoW Firefox example; clarified the intro; corrected the `--browser-version` default |
| `/reference/qscloud` | `--browser` example and description; `--browser-version` default |
| `/reference/qseow` | Example now uses `--browser-version recommended` |
| `/reference/supported-versions` | Removed the Firefox thumbnail example |
| `/guide/configuration/qseow`, `/guide/configuration/qlik-sense-cloud` | Browser selection snippets |
| `/guide/concepts/browser-detection-and-environment-variables` | Browser type now distinguishes thumbnail commands from `browser` commands |

## Checklist

- [x] This PR targets `next`
- [x] `npm run docs:build` passes locally (the build fails on dead internal links)
- [x] Internal links are absolute and extensionless
- [x] New pages have a sidebar entry in `docs/.vitepress/config.js` — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [ ] Checked the Cloudflare Pages preview link once the build finishes

The new `#supported-browsers` anchor, which four pages now link to, was verified against the generated HTML — the build does not validate fragments.

## Notes for reviewers

**Deliberately scoped to correctness, not completeness.** This fixes what would break a reader on 4.0.0. It does not document the new browser-version vocabulary (`recommended`, `stable`, per-browser channel keywords, channel-prefixed Firefox build ids) — `browser-version-selection.md` in the BSI staging folder covers that properly and is still pending review.

Two things that are stale but not breaking are therefore left alone for that draft: `/reference/browser` still says Firefox supports only `latest`, and the `browser list-available` note about Firefox making no network call.
