### PR TITLE
docs: publish for Butler Sheet Icons 4.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,25 @@ npm run docs:preview      # Preview production build locally
 
 There is no deploy script. Deployment is automatic — see "Deployment & Hosting" below.
 
+### Viewing the site locally
+
+Run the dev server and open it in a browser to see changes rendered:
+
+```bash
+npm run docs:dev
+```
+
+The server runs until stopped. Open the URL printed at the end of its output — **read the port from that output rather than assuming 5173**, because VitePress falls back to 5174, 5175 and so on when the port is taken:
+
+```
+  ➜  Local:   http://localhost:5174/
+```
+
+Two things worth knowing about the dev server:
+
+- **`curl` will not show page content.** It returns an empty SPA shell and renders client-side, so grepping the response for a heading you just added finds nothing even when the page is fine. Use a browser, or build with `npm run docs:build` and read `docs/.vitepress/dist/` for static HTML.
+- **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected** on startup and harmless.
+
 ## Content Guidelines
 
 ### Writing Style

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,16 @@ Two things worth knowing about the dev server:
 - **`curl` will not show page content.** It returns an empty SPA shell and renders client-side, so grepping the response for a heading you just added finds nothing even when the page is fine. Use a browser, or build with `npm run docs:build` and read `docs/.vitepress/dist/` for static HTML.
 - **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected** on startup and harmless.
 
+### Always share the Cloudflare preview URL
+
+Every pushed branch is built by Cloudflare Pages and published to its own URL. **Include that URL whenever you report work on a branch** — it lets the change be reviewed rendered, without checking anything out.
+
+Read it from the "Cloudflare Pages" check run on the branch's head commit rather than constructing it. Give the branch alias, which follows the branch; the other URL in that output is pinned to a single commit.
+
+**The alias is not simply the branch name.** Cloudflare lowercases it, replaces non-alphanumeric characters with `-`, and truncates to 28 characters, so `docs/exit-code-reflects-failures` becomes `docs-exit-code-reflects-fail.butler-sheet-icons-docs.pages.dev`. Guessed URLs 404 for anything longer.
+
+Allow a minute or two after pushing for the build to finish, and say so when a branch has no rendered changes to look at.
+
 ## Content Guidelines
 
 ### Writing Style

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,10 +152,12 @@ This site is **not** deployed via GitHub Pages. There is no `gh-pages` branch in
 
 ### Branch Model
 
-**All work goes to `next`.** Branch off `next`, PR into `next`. There is no per-change branch decision.
+**All work goes to `next`.** Branch off `next`, PR into `next`. There is no per-change branch decision and no exception — `.github/` templates and workflows included.
 
-- `next` — where all documentation work goes. Preview URL only.
+- `next` — the repository's **default branch**, and where all documentation work goes. A fresh clone or worktree already starts here. Preview URL only.
 - `main` — production, what the public site serves. Reached only by merging `next` at BSI release time.
+
+A repository ruleset covers both branches: pull requests are required, direct and force pushes rejected, no approvals needed.
 
 The site is single-version — one copy of the docs, no per-release archive — so anything on `main` is presented as documentation for the current BSI release whatever it actually describes, and Cloudflare publishes it within minutes. Routing everything through `next` keeps unreleased documentation off the public site. Writing to `main` directly is a deliberate production hotfix, not a normal option.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,42 @@ Two things about the dev server that will otherwise waste your time:
 
 Stop the server when you are done.
 
+## Always give the user the Cloudflare preview URL
+
+Every branch pushed to GitHub is built by Cloudflare Pages and published to its own URL. **Include
+that URL whenever you report work on a branch.** It is how the user reviews rendered output without
+checking anything out, and it works from any device.
+
+Read it from the Cloudflare Pages check run rather than constructing it:
+
+```bash
+sha=$(gh pr view <PR> --repo ptarmiganlabs/butler-sheet-icons-docs --json headRefOid --jq '.headRefOid')
+gh api repos/ptarmiganlabs/butler-sheet-icons-docs/commits/$sha/check-runs \
+  --jq '.check_runs[]|select(.name|test("Cloudflare"))|.output.summary'
+```
+
+That output contains two URLs. Give the **branch alias** — it follows the branch as you push more
+commits. The other is pinned to a single commit (an 8-hex-character prefix); use it only when you
+deliberately want a link that will not move.
+
+**Do not assume the alias is the branch name.** Cloudflare lowercases it, replaces every
+non-alphanumeric character with `-`, and **truncates to 28 characters**:
+
+| Branch | Alias |
+| --- | --- |
+| `next` | `next.butler-sheet-icons-docs.pages.dev` |
+| `docs/exit-code-reflects-failures` | `docs-exit-code-reflects-fail.butler-sheet-icons-docs.pages.dev` |
+| `docs/local-testing-instructions` | `docs-local-testing-instructi.butler-sheet-icons-docs.pages.dev` |
+
+Branch names over 28 characters are cut mid-word, so a guessed URL 404s. Read it from the check run.
+
+Two things to mention alongside the link when they apply:
+
+- The build takes a minute or two after a push, so a URL given immediately may 404 briefly.
+- A branch with no rendered changes — one that only touches `CLAUDE.md`, workflows or other
+  repository files — has nothing to look at. Say so rather than sending the user to an identical
+  page.
+
 ## Verify before reporting done
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,36 @@ reviewable without diffing the branch.
   only by search.
 - Write for **Qlik Sense administrators**, not Node.js developers.
 
+## Testing the site locally
+
+You can run the site and look at it yourself. Do this whenever a change is visual, structural, or
+worth seeing rendered — do not ask the user to check something you can check.
+
+```bash
+npm run docs:dev
+```
+
+The server runs until stopped, so start it in the background. Then open the URL printed at the end
+of its output in a browser and navigate the site as a reader would.
+
+**Read the port from that output — do not assume 5173.** VitePress falls back to 5174, 5175 and so
+on whenever the port is already taken, which happens often:
+
+```
+  ➜  Local:   http://localhost:5174/
+```
+
+Two things about the dev server that will otherwise waste your time:
+
+- **`curl` cannot see page content.** The dev server returns an empty SPA shell and renders
+  everything client-side, so `curl … | grep 'my new heading'` finds nothing even when the page is
+  perfectly fine. Use a real browser. If you want HTML you can grep, run `npm run docs:build` and
+  read `docs/.vitepress/dist/` instead.
+- **`Failed to resolve dependency: debug, present in 'optimizeDeps.include'` is expected noise.**
+  It appears on most starts and the server works regardless. Do not chase it.
+
+Stop the server when you are done.
+
 ## Verify before reporting done
 
 ```bash
@@ -73,7 +103,7 @@ npm run docs:build
 
 Fails on dead internal links, so a passing build proves every internal link resolves. It does
 **not** validate `#anchor` fragments — check those against the generated HTML in
-`docs/.vitepress/dist/`.
+`docs/.vitepress/dist/`, e.g. `grep -o 'id="[^"]*"' docs/.vitepress/dist/reference/commands.html`.
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,9 @@ published at <https://butler-sheet-icons.ptarmiganlabs.com>.
 
 ## Branch rule
 
-**All work goes to `next`.** Branch off an up-to-date `next`, PR into `next`.
+**All work goes to `next`.** It is the repository's default branch, so a fresh clone or worktree
+already starts there. Branch off an up-to-date `next`, PR into `next`. There are no exceptions —
+`.github/` templates and workflows included.
 
 `main` is production — it is what the public site serves, and Cloudflare Pages publishes it
 automatically within minutes of a merge. It is reached only by merging `next` at BSI release time,
@@ -14,13 +16,15 @@ which is a separate maintenance step documented in [README_DEPLOY.md](./README_D
 Writing to `main` directly is a deliberate production hotfix, not a normal option. Do not choose
 it without being asked to.
 
-One narrow exception: GitHub reads the pull request template and the issue templates under
-`.github/` **only from the default branch**, so a change to those has no effect until it is on
-`main` and targets `main` directly. This does not extend to anything under `docs/` — that is site
-content and always goes to `next`.
+**Check your starting point before your first edit**, not before your first commit — editing a tree
+that predates `next` produces content that duplicates or contradicts what is already there:
 
-A repository ruleset requires a pull request for `main` and rejects direct and force pushes. No
-approvals are required.
+```bash
+git fetch origin && git merge-base --is-ancestor origin/next HEAD || git rebase origin/next
+```
+
+A repository ruleset covers both `main` and `next`: pull requests are required, and direct and
+force pushes are rejected. No approvals are required, so you can merge your own once checks pass.
 
 ## Where new documentation comes from
 

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -42,9 +42,11 @@ Two long-lived branches.
 ### Which branch does my change go to?
 
 **`next`. Always.** Branch off an up-to-date `next`, PR into `next`. There is no decision
-to make.
+to make, and no exception — `.github/` templates and workflows included.
 
-`main` is reached only by merging `next` at release time, per the procedure below.
+`next` is the repository's **default branch**, so a fresh clone or worktree already starts
+there, GitHub reads the pull request and issue templates from it, and Dependabot targets
+it. `main` is reached only by merging `next` at release time, per the procedure below.
 
 The site is single-version: there is exactly one copy of the docs and no per-release
 archive. So content merged to `main` is presented as documentation for the current
@@ -57,11 +59,16 @@ The cost is that a correction to an already-live page waits for the next release
 If something on production genuinely cannot wait, that is a deliberate hotfix branched
 off `main` — an exception, not one of two normal options.
 
-There is one other narrow exception. GitHub reads a few repository files **only from the
-default branch**, `main` — the pull request template and the issue templates under
-`.github/`. A fix to those has no effect until it is on `main`, so it targets `main`
-directly. This does not extend to anything under `docs/`, which is site content and
-always goes to `next`.
+A repository ruleset covers **both** `main` and `next`: pull requests are required, and
+direct and force pushes are rejected. No approvals are required, so you can merge your own
+once checks pass.
+
+> [!WARNING]
+> **If you ever change the default branch again**, check the ruleset first. It lists
+> `refs/heads/main` and `refs/heads/next` explicitly, but also carries the symbolic
+> `~DEFAULT_BRANCH`, which **follows** whichever branch is default. Relying on that alone
+> silently unprotects the branch you just demoted — which is exactly what happened when
+> `next` was made default. Keep the explicit refs.
 
 ### At release time
 

--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -157,7 +157,7 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 :::
 
-### Specify browser type (Chrome/Firefox)
+### Specify browser type
 
 ::: code-group
 
@@ -183,7 +183,7 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 :::
 
-Using Firefox works the same, set `--browser firefox`.
+`chrome` is the only value the thumbnail commands accept. Firefox can be installed and removed with the `browser` commands, but cannot render thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Use a specific browser version
 
@@ -233,10 +233,10 @@ Browsers in Docker are downloaded inside the container.
 # List browsers in container
 docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
 
-# Install Firefox in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser firefox
+# Install a specific Chrome build in container
+docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
 
-# Use Firefox for sheet icons
+# Use that build for sheet icons
 docker run -it --rm \
   -v $(pwd)/images:/nodeapp/img \
   ptarmiganlabs/butler-sheet-icons:latest \
@@ -246,7 +246,8 @@ docker run -it --rm \
   --logonuserid user@company.com \
   --logonpwd mypassword \
   --appid 12345678-1234-1234-1234-123456789012 \
-  --browser firefox \
+  --browser chrome \
+  --browser-version 121.0.6167.85 \
   --headless true
 ```
 
@@ -254,10 +255,10 @@ docker run -it --rm \
 # List browsers in container
 docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
 
-# Install Firefox in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser firefox
+# Install a specific Chrome build in container
+docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
 
-# Use Firefox for sheet icons
+# Use that build for sheet icons
 docker run -it --rm `
   -v ${PWD}/images:/nodeapp/img `
   ptarmiganlabs/butler-sheet-icons:latest `
@@ -267,7 +268,8 @@ docker run -it --rm `
   --logonuserid user@company.com `
   --logonpwd mypassword `
   --appid 12345678-1234-1234-1234-123456789012 `
-  --browser firefox `
+  --browser chrome `
+  --browser-version 121.0.6167.85 `
   --headless true
 ```
 
@@ -397,7 +399,7 @@ docker run -it --rm `
 1. Use visible mode when debugging login issues
 2. Keep multiple browser versions for compatibility testing
 3. Use verbose logging to understand behavior
-4. Test with both Chrome and Firefox
+4. Test against more than one Chrome build before pinning one
 
 ### CI/CD
 

--- a/docs/guide/advanced/ci-cd.md
+++ b/docs/guide/advanced/ci-cd.md
@@ -146,11 +146,11 @@ export https_proxy='http://username:password@proxy.example.com:port'
 
 ## Exit codes and job status
 
-::: danger Action may be required — requires BSI 3.12.0 or later
+::: danger Action may be required — requires BSI 4.0.0 or later
 This change can turn a scheduled job that always reported success into one that reports failure. That is intended, but read this before upgrading so it does not surprise you at 3am.
 :::
 
-Until BSI 3.12.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
+Until BSI 4.0.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
 
 BSI now exits `1` when the run failed or completed with apps it could not process. See [Exit codes](/reference/commands#exit-codes) for exactly what counts as a failure.
 

--- a/docs/guide/advanced/ci-cd.md
+++ b/docs/guide/advanced/ci-cd.md
@@ -144,14 +144,57 @@ export http_proxy='http://username:password@proxy.example.com:port'
 export https_proxy='http://username:password@proxy.example.com:port'
 ```
 
+## Exit codes and job status
+
+::: danger Action may be required — requires BSI 3.12.0 or later
+This change can turn a scheduled job that always reported success into one that reports failure. That is intended, but read this before upgrading so it does not surprise you at 3am.
+:::
+
+Until BSI 3.12.0, Butler Sheet Icons always exited with `0`. A run in which every app failed finished with the same exit code as a run in which everything worked — the only way to tell them apart was to read the log. A pipeline step that checked the exit code was, in effect, checking nothing.
+
+BSI now exits `1` when the run failed or completed with apps it could not process. See [Exit codes](/reference/commands#exit-codes) for exactly what counts as a failure.
+
+### Before you upgrade
+
+**If you only run BSI interactively, there is nothing to do** — the exit code is not something you normally see.
+
+**If you run it from automation, check what your job does with a non-zero exit code.** Most schedulers treat it as a failed job and may raise an alert, stop the pipeline, or skip later steps.
+
+Run your existing command once by hand after upgrading and inspect the exit code:
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons qscloud create-sheet-thumbnails --tenanturl $env:BSI_TENANT_URL --apikey $env:BSI_API_KEY
+Write-Host "exit code: $LASTEXITCODE"
+```
+
+```bash [Bash]
+butler-sheet-icons qscloud create-sheet-thumbnails --tenanturl "$BSI_TENANT_URL" --apikey "$BSI_API_KEY"
+echo "exit code: $?"
+```
+
+:::
+
+**If it returns `1`, that is a real problem that was already happening** — it was simply invisible before. Read the log for the messages listed in [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes) and fix the underlying cause.
+
+If you need the job to keep running while you investigate, most schedulers let you ignore a step's exit code. Treat that as temporary: the exit code is telling you that sheet icons are not being updated the way you asked.
+
+### Retrying a failed run
+
+An app is saved once, after all its sheets have been dealt with. If that save fails, nothing about the app changes and its sheets keep the icons they had, so re-running is a clean retry rather than a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).
+
 ## Troubleshooting in CI
 
 - Use `--headless true` (default) on build agents. Consider `--headless false` only for local debugging.
 - For QSEoW, always provide `--sense-version` that matches your server.
 - In Qlik Cloud, updating published apps affects only private sheets—use sheet status filters to avoid “Access denied”.
+- A non-zero exit code is now meaningful — see [Exit codes and job status](#exit-codes-and-job-status) above.
 
 ## Related
 
-- Environment Variables: naming scheme and examples
-- Docker Usage: tips and troubleshooting for running BSI in containers
-- Sheet Exclusion and Sheet Blurring: control visibility vs. privacy in pipelines
+- [Exit codes](/reference/commands#exit-codes): what `0` and `1` mean, and what counts as a failure
+- [Environment variables](/guide/concepts/environment-variables): naming scheme and examples
+- [Docker usage](/guide/advanced/docker): tips and troubleshooting for running BSI in containers
+- [Sheet exclusion](/guide/concepts/sheet-exclusion) and [Sheet blurring](/guide/concepts/sheet-blurring): control visibility vs. privacy in pipelines
+- [Troubleshooting](/guide/troubleshooting): symptom-based diagnosis

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -56,7 +56,7 @@ If no system browser is configured, BSI looks in the Puppeteer cache directory (
 
 A cached browser is used when it matches **both** of these:
 
-- **Browser type** — the browser asked for with `--browser` (`chrome` or `firefox`).
+- **Browser type** — the browser asked for with `--browser`. The thumbnail commands accept `chrome` only; the `browser` commands also accept `firefox`.
 - **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly that build ID is used. If a different version is cached, BSI treats it as no match and downloads the version you asked for. If `--browser-version` is `latest` (the default), any cached build of the requested browser type is accepted.
 
 When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -69,8 +69,8 @@ With `--browser-version latest`, BSI does **not** check whether a newer browser 
 If several builds of the same browser are cached, do not rely on which one gets picked. Pin `--browser-version` to an exact build ID whenever the exact version matters.
 :::
 
-::: warning Requires BSI 3.12.0 or later
-In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 3.12.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
+::: warning Requires BSI 4.0.0 or later
+In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 4.0.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
 :::
 
 ### 3. Download browser (lowest priority)
@@ -113,8 +113,8 @@ Run `browser install` once while the machine still has internet access. The brow
 Setting `PUPPETEER_EXECUTABLE_PATH` to a browser installed by other means works too, and is the usual approach for Docker and centrally managed environments. See [Strategy 2](#strategy-2-use-a-system-browser-via-puppeteer-executable-path-controlled) and [Strategy 3](#strategy-3-use-a-pre-cached-browser-semi-offline) below.
 :::
 
-::: warning Requires BSI 3.12.0 or later
-Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 3.12.0 the messages above are shown instead.
+::: warning Requires BSI 4.0.0 or later
+Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 4.0.0 the messages above are shown instead.
 :::
 
 ## Key environment variables

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -14,10 +14,28 @@ In addition to the cached browsers managed by BSI, you can also point BSI at a s
 
 ## Supported Browsers
 
-Butler Sheet Icons supports two major browsers:
+Butler Sheet Icons manages two browsers, but they are not interchangeable:
 
-- **Chrome**: Full version control available, including specific build numbers
-- **Firefox**: Latest version available (specific version control pending)
+- **Chrome**: the only browser that can render sheet thumbnails. Full version control available, including specific build numbers.
+- **Firefox**: can be installed, listed and removed with the `browser` commands, but **cannot be used to create thumbnails**.
+
+::: warning Firefox is not available for thumbnails — BSI 4.0.0 or later
+`--browser firefox` is rejected by `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`:
+
+```
+error: option '--browser <browser>' argument 'firefox' is invalid. Allowed choices are chrome.
+```
+
+The same applies when the value comes from an environment variable:
+
+```
+error: option '--browser <browser>' value 'firefox' from env 'BSI_QSEOW_CST_BROWSER' is invalid. Allowed choices are chrome.
+```
+
+Firefox never actually worked for thumbnail creation — the rendering path drives the browser over the Chrome DevTools Protocol with a Chromium-only argument list — but earlier versions accepted the option and then failed later, in a way that was hard to interpret. It is now rejected up front.
+
+`browser install`, `browser uninstall`, `browser uninstall-all` and `browser list-available` still accept `--browser firefox`.
+:::
 
 ## Browser Cache Location
 
@@ -88,22 +106,16 @@ When running sheet icon creation commands, you can specify which browser to use 
 ::: code-group
 
 ```bash [Bash]
-# Use Chrome (default)
+# Use Chrome (the only browser accepted here, and the default)
 butler-sheet-icons qscloud create-sheet-icons --browser chrome ...
-
-# Use Firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
 
 # Use specific Chrome version
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 ```
 
 ```powershell [PowerShell]
-# Use Chrome (default)
+# Use Chrome (the only browser accepted here, and the default)
 butler-sheet-icons qscloud create-sheet-icons --browser chrome ...
-
-# Use Firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
 
 # Use specific Chrome version
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
@@ -125,7 +137,7 @@ Chrome versions use build numbers (e.g., `121.0.6167.85`). Butler Sheet Icons su
 
 ### Firefox Versions
 
-Firefox currently supports only the latest version. Specific version control is planned for future releases.
+Firefox is managed only by the `browser` commands — it cannot render thumbnails, so its version affects nothing about a thumbnail run. Firefox build ids are channel-prefixed, for example `stable_153.0.3`.
 
 ## Headless vs. Visible Browser
 
@@ -250,23 +262,23 @@ For testing different configurations:
 ::: code-group
 
 ```bash [Bash]
-# Test with Chrome
+# Test a specific Chrome build
 butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 
-# Test with Firefox
-butler-sheet-icons browser install --browser firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+# Test another Chrome build
+butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
 ```
 
 ```powershell [PowerShell]
-# Test with Chrome
+# Test a specific Chrome build
 butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
 butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 121.0.6167.85 ...
 
-# Test with Firefox
-butler-sheet-icons browser install --browser firefox
-butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+# Test another Chrome build
+butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
 ```
 
 :::

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -35,7 +35,7 @@ When running Butler Sheet Icons for the first time, you have several options. Th
 
 ### Automatic Download (Default)
 
-If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed). From BSI 3.12.0 the download happens only once — later runs find the browser in the cache and reuse it, needing no download and no internet access for the browser itself. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority) for the exact matching rules.
+If no browser is specified, BSI will automatically download the latest stable version of Chrome (when needed). From BSI 4.0.0 the download happens only once — later runs find the browser in the cache and reuse it, needing no download and no internet access for the browser itself. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority) for the exact matching rules.
 
 ::: code-group
 

--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -43,7 +43,7 @@ graph TD
 
 ### When the app is saved
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions saved the app once per sheet.
 :::
 

--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -39,6 +39,23 @@ graph TD
 
 1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages.
 
+1. Save the app — Once every sheet has been dealt with, the app is saved **once**. See below.
+
+### When the app is saved
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions saved the app once per sheet.
+:::
+
+Butler Sheet Icons saves each app a single time, at the end of processing it, and only if at least one sheet actually changed.
+
+This matters in two ways:
+
+- **App version history.** An app with forty sheets used to gain forty versions in Qlik Sense on every run. It now gains one. An app where nothing needed changing gains none at all.
+- **Failed runs change nothing.** Because the save happens after every sheet has been handled, a run that fails before it — a published app, or one the account running Butler Sheet Icons cannot write to — leaves the app **completely untouched**, with its sheets keeping the icons they had. Previously the sheets processed before the failure had already been written, leaving the app with a mix of old and new icons.
+
+Re-running after a failure is therefore a clean retry rather than a resume. See [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes).
+
 ## Tips and pointers
 
 - Toggle headless mode or slow down navigation when debugging. See [Browser management](/guide/concepts/browser-management).
@@ -56,3 +73,5 @@ graph TD
 - Configuration (QSEoW): [/guide/configuration/qseow](/guide/configuration/qseow)
 - Commands reference: [/reference/commands](/reference/commands)
 - Browser reference: [/reference/browser](/reference/browser)
+- Exit codes: [/reference/commands#exit-codes](/reference/commands#exit-codes)
+- Run failures and exit codes: [/guide/troubleshooting#run-failures-and-exit-codes](/guide/troubleshooting#run-failures-and-exit-codes)

--- a/docs/guide/concepts/how-it-works.md
+++ b/docs/guide/concepts/how-it-works.md
@@ -37,7 +37,7 @@ graph TD
 
 1. Process images — Resizes to thumbnail and optionally produces a blurred variant for sensitive content. Details in [Sheet blurring](/guide/concepts/sheet-blurring).
 
-1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages.
+1. Upload and assign — Uploads images (QSEoW via QRS content libraries, QS Cloud via cloud APIs) and assigns them to sheets. Options are covered in the platform-specific configuration pages. **If any image fails to upload, the app is left alone** rather than being pointed at images that are not there — see [`Failed to upload N of M thumbnail image(s)`](/guide/troubleshooting#failed-to-upload-n-of-m-thumbnail-image-s).
 
 1. Save the app — Once every sheet has been dealt with, the app is saved **once**. See below.
 

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -41,16 +41,29 @@ In earlier versions `--blur-sheet-number` blurred sheets you had not selected �
 
 Control blur strength with `--blur-factor <factor>`.
 
-- Range: 0 = no blur … 1000 = full blur.
-- CLI help shows default: 10. Choose a value that balances privacy with recognizability.
+- **Range: 1–100.** 1 is the lightest blur, 100 the heaviest.
+- **Default: 5.** Choose a value that balances privacy with recognizability.
+
+Two things are worth knowing before you pick a value:
+
+- **A value above 100 is accepted but capped at 100.** `--blur-factor 1000` runs without an error or a warning and produces exactly the same image as `--blur-factor 100`.
+- **`--blur-factor 0` does not mean "no blur".** Values below 1 are treated as 1, so the lightest blur you can ask for is 1. To leave a sheet unblurred, do not select it with any of the `--blur-sheet-...` filters.
+
+A value that is not a non-negative whole number is rejected before Butler Sheet Icons connects to Qlik Sense:
+
+```
+error: option '--blur-factor <factor>' argument 'abc' is invalid. Blur factor must be a non-negative integer.
+```
 
 ### Blur effect examples
 
+The first row is the unmodified thumbnail, shown for comparison — it is not a `--blur-factor` value.
+
 | Blur Factor | Result                                                           |
 | ----------- | ---------------------------------------------------------------- |
-| 0           | ![No blur](/images/blur-factor-0.png "No blur applied")          |
-| 5           | ![Light blur](/images/blur-factor-5.png "Light blur applied")    |
-| 10          | ![Medium blur](/images/blur-factor-10.png "Medium blur applied") |
+| Not blurred | ![Unblurred sheet thumbnail](/images/blur-factor-0.png "Thumbnail with no blur applied") |
+| 5           | ![Sheet thumbnail with light blur](/images/blur-factor-5.png "Light blur applied")    |
+| 10          | ![Sheet thumbnail with medium blur](/images/blur-factor-10.png "Medium blur applied") |
 
 ## Examples
 

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -31,6 +31,12 @@ QSEoW only:
 - `--blur-sheet-tag <value...>`
   Blur sheets that have one or more specified tags (set in QMC > App objects). Tags don’t exist for individual sheets in QS Cloud.
 
+::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+In earlier versions `--blur-sheet-number` blurred sheets you had not selected — only the last number you listed was used, and it was matched as a text fragment rather than as a whole sheet number. `--blur-sheet-number 12` also blurred sheets 1 and 2.
+
+`--blur-sheet-title`, `--blur-sheet-status` and `--blur-sheet-tag` were not affected. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers) for the full description, and [Sheets you did not select were skipped or blurred](/guide/troubleshooting#sheets-you-did-not-select-were-skipped-or-blurred) for what to check and re-run.
+:::
+
 ## Blur intensity
 
 Control blur strength with `--blur-factor <factor>`.

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -31,7 +31,7 @@ QSEoW only:
 - `--blur-sheet-tag <value...>`
   Blur sheets that have one or more specified tags (set in QMC > App objects). Tags don’t exist for individual sheets in QS Cloud.
 
-::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+::: warning Sheet numbers were matched incorrectly before BSI 4.0.0
 In earlier versions `--blur-sheet-number` blurred sheets you had not selected — only the last number you listed was used, and it was matched as a text fragment rather than as a whole sheet number. `--blur-sheet-number 12` also blurred sheets 1 and 2.
 
 `--blur-sheet-title`, `--blur-sheet-status` and `--blur-sheet-tag` were not affected. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers) for the full description, and [Sheets you did not select were skipped or blurred](/guide/troubleshooting#sheets-you-did-not-select-were-skipped-or-blurred) for what to check and re-run.

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -20,7 +20,7 @@ Filters mirror the exclusion options but use the `--blur-sheet-...` prefix. You 
 Available in QS Cloud and QSEoW:
 
 - `--blur-sheet-number <numbers...>`
-  Blur by position in the app (1 = first sheet). Example: `--blur-sheet-number 1 3 5`.
+  Blur by position in the app (1 = first sheet). Example: `--blur-sheet-number 1 3 5`. Sheet numbers come from the sheets' display order — see [How sheet numbers are decided](/guide/concepts/sheet-exclusion#how-sheet-numbers-are-decided).
 - `--blur-sheet-title <titles...>`
   Blur by exact sheet title. Titles with spaces must be quoted.
 - `--blur-sheet-status <status...>`

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -38,10 +38,10 @@ Tip: Titles with spaces must be wrapped in quotes.
 
 `--exclude-sheet-number` and `--blur-sheet-number` refer to a sheet's position in the app, where 1 is the first sheet. That position comes from the sheets' display order in Qlik Sense, which Butler Sheet Icons reads from the engine before doing anything else.
 
-::: warning Numbering can shift in apps with an incomplete sheet — BSI 3.12.0 or later
+::: warning Numbering can shift in apps with an incomplete sheet — BSI 4.0.0 or later
 A sheet missing its layout data has no usable position, so it is placed **at the end** of the sheet list. In an app containing such a sheet, numbering can therefore differ from what you might expect.
 
-In practice there is nothing to migrate: before BSI 3.12.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
+In practice there is nothing to migrate: before BSI 4.0.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
 
 Apps whose sheets all have complete layout data are numbered exactly as before.
 :::
@@ -65,7 +65,7 @@ error: option '--exclude-sheet-number <number...>' argument 'abc' is invalid. Ex
 
 Each of these two options can also be set through an environment variable, but a variable holds **one** sheet number only — see [QSEoW reference](/reference/qseow#sheet-filtering) and [QS Cloud reference](/reference/qscloud#sheet-filtering). To select several sheets, use the command-line option.
 
-::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+::: warning Sheet numbers were matched incorrectly before BSI 4.0.0
 In earlier versions `--exclude-sheet-number` and `--blur-sheet-number` selected the wrong sheets. Two faults combined:
 
 - **Only the last number you listed was used.** `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`, so sheet 3 was processed as normal.

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -13,7 +13,7 @@ Exclude sheets when creating thumbnails to keep special-purpose sheets unchanged
 Available in both QS Cloud and QSEoW:
 
 - --exclude-sheet-number <numbers...>
-  Exclude by position in the app (1 = first sheet).
+  Exclude by position in the app (1 = first sheet). See [How sheet numbers are decided](#how-sheet-numbers-are-decided).
 - --exclude-sheet-title <titles...>
   Exclude by exact sheet title. Titles with spaces must be quoted.
 - --exclude-sheet-status <status...>
@@ -33,6 +33,20 @@ Example parameters usage:
 ```
 
 Tip: Titles with spaces must be wrapped in quotes.
+
+## How sheet numbers are decided
+
+`--exclude-sheet-number` and `--blur-sheet-number` refer to a sheet's position in the app, where 1 is the first sheet. That position comes from the sheets' display order in Qlik Sense, which Butler Sheet Icons reads from the engine before doing anything else.
+
+::: warning Numbering can shift in apps with an incomplete sheet — BSI 3.12.0 or later
+A sheet missing its layout data has no usable position, so it is placed **at the end** of the sheet list. In an app containing such a sheet, numbering can therefore differ from what you might expect.
+
+In practice there is nothing to migrate: before BSI 3.12.0 those apps failed outright rather than being processed with different numbers. See [`TypeError: Cannot read properties of undefined (reading 'rank')`](/guide/troubleshooting#typeerror-cannot-read-properties-of-undefined-reading-rank) in Troubleshooting.
+
+Apps whose sheets all have complete layout data are numbered exactly as before.
+:::
+
+If you rely on sheet numbers, check them in the log of a successful run before trusting them — Butler Sheet Icons names each sheet by number, title and ID as it processes it.
 
 ## Excluding sheets based on the sheet's status
 

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -48,6 +48,36 @@ Apps whose sheets all have complete layout data are numbered exactly as before.
 
 If you rely on sheet numbers, check them in the log of a successful run before trusting them — Butler Sheet Icons names each sheet by number, title and ID as it processes it.
 
+## Listing several sheet numbers
+
+`--exclude-sheet-number` and `--blur-sheet-number` both take one or more whole numbers, separated by spaces, where 1 is the first sheet in the app:
+
+```bash
+--exclude-sheet-number 1 2 12
+--blur-sheet-number 4 7
+```
+
+A value that is not a non-negative whole number is rejected before Butler Sheet Icons connects to Qlik Sense:
+
+```
+error: option '--exclude-sheet-number <number...>' argument 'abc' is invalid. Exclude sheet number must be a non-negative integer.
+```
+
+Each of these two options can also be set through an environment variable, but a variable holds **one** sheet number only — see [QSEoW reference](/reference/qseow#sheet-filtering) and [QS Cloud reference](/reference/qscloud#sheet-filtering). To select several sheets, use the command-line option.
+
+::: warning Sheet numbers were matched incorrectly before BSI 3.12.0
+In earlier versions `--exclude-sheet-number` and `--blur-sheet-number` selected the wrong sheets. Two faults combined:
+
+- **Only the last number you listed was used.** `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`, so sheet 3 was processed as normal.
+- **Numbers were matched as text fragments rather than as whole sheet numbers.** `--exclude-sheet-number 12` also excluded sheets 1 and 2, and `--exclude-sheet-number 123` also excluded sheets 1, 2, 3, 12 and 23.
+
+A single one-digit number, such as `--exclude-sheet-number 3`, was always handled correctly — no other sheet number hides inside "3".
+
+No error or warning was produced and the run reported success, so there was nothing to notice at the time. If you use either option, see [Sheets you did not select were skipped or blurred](/guide/troubleshooting#sheets-you-did-not-select-were-skipped-or-blurred) for how to check what happened and what to re-run.
+
+The other sheet filters — `--exclude-sheet-status`, `--exclude-sheet-tag`, `--exclude-sheet-title`, `--blur-sheet-status` and `--blur-sheet-title` — were never affected.
+:::
+
 ## Excluding sheets based on the sheet's status
 
 Sheets can have different statuses, and how they are handled differs between QS Cloud and QSEoW:

--- a/docs/guide/configuration/qlik-sense-cloud.md
+++ b/docs/guide/configuration/qlik-sense-cloud.md
@@ -217,8 +217,8 @@ butler-sheet-icons qscloud create-sheet-icons `
 ### Browser Configuration
 
 ```bash
-# Use specific browser
---browser firefox
+# Browser selection (chrome is the only accepted value)
+--browser chrome
 
 # Show browser (for debugging)
 --headless false

--- a/docs/guide/configuration/qseow.md
+++ b/docs/guide/configuration/qseow.md
@@ -333,8 +333,8 @@ BSI can update icons for Public, Published, and Private sheets in both published
 
 ```bash
 # Browser selection
---browser chrome              # or firefox
---browser-version latest      # or specific version
+--browser chrome              # chrome is the only accepted value
+--browser-version recommended # or stable, a channel, or an exact build
 --headless false              # Show browser for debugging
 ```
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -33,7 +33,7 @@ butler-sheet-icons browser list-installed
 
 ## Run Failures and Exit Codes
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions always exited with `0`. If your automation never reported a failure before upgrading, that is why — see [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status).
 :::
 
@@ -109,7 +109,7 @@ On Qlik Sense Enterprise on Windows the message names the content library instea
 QSEOW: qseowProcessApp (stack): QseowError: Failed to upload 2 of 5 thumbnail image(s) to content library BSI thumbnails
 ```
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 In earlier versions the run carried on after a failed upload and repointed **every** sheet at an image that was not there, replacing working icons with broken ones — and reported no error. If apps are showing broken sheet icons from an earlier run, see "Repairing apps affected before upgrading" below.
 :::
 
@@ -129,7 +129,7 @@ If earlier runs left apps showing broken sheet icons, re-running `create-sheet-t
 
 A single sheet missing its layout data caused the **whole app** to be abandoned before any thumbnail was created or removed. Every other sheet in that app was left untouched.
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Fixed. Such sheets are now sorted to the end of the sheet list and processed like any other, so the app completes.
 :::
 
@@ -404,7 +404,7 @@ Browser-related problems are among the most common issues when using Butler Shee
 
 - `browser list-available` reports that `versionhistory.googleapis.com` could not be reached
 - `browser install` reports that the requested version "cannot be downloaded"
-- On BSI versions before 3.12.0, `browser list-available` instead printed a raw stack trace such as `TypeError: Cannot read properties of undefined (reading 'status')`, with line numbers from inside the BSI binary
+- On BSI versions before 4.0.0, `browser list-available` instead printed a raw stack trace such as `TypeError: Cannot read properties of undefined (reading 'status')`, with line numbers from inside the BSI binary
 
 **Cause:**
 
@@ -851,7 +851,7 @@ export http_proxy=http://user:pass@proxy.company.com:8080
 
 **Cause:**
 
-Butler Sheet Icons before 3.12.0 read these two options incorrectly, in two ways at once:
+Butler Sheet Icons before 4.0.0 read these two options incorrectly, in two ways at once:
 
 - Only the last number you listed was used. `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`.
 - That number was then matched as a text fragment rather than as a whole sheet number, so `--exclude-sheet-number 12` also excluded sheets 1 and 2.
@@ -876,7 +876,7 @@ Blurred sheet thumbnail (via sheet number): 1: 'Sales overview', ...
 
 **Solutions:**
 
-1. **Upgrade to BSI 3.12.0 or later.** Both options now keep every number you list and match each as a whole sheet number.
+1. **Upgrade to BSI 4.0.0 or later.** Both options now keep every number you list and match each as a whole sheet number.
 
 2. **Re-check your options before re-running.** If you worked around the old behaviour — listing sheet numbers one run at a time, or picking numbers that avoided the overlap — those workarounds are no longer needed and will now produce the wrong result.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -841,6 +841,49 @@ export http_proxy=http://user:pass@proxy.company.com:8080
 
 ## Sheet-Specific Issues
 
+### Sheets you did not select were skipped or blurred
+
+**Symptoms:**
+
+- Sheets you never listed in `--exclude-sheet-number` kept their old icons
+- Sheets you never listed in `--blur-sheet-number` came out blurred
+- The run reported success — there was no error or warning
+
+**Cause:**
+
+Butler Sheet Icons before 3.12.0 read these two options incorrectly, in two ways at once:
+
+- Only the last number you listed was used. `--exclude-sheet-number 3 7` behaved as though you had written `--exclude-sheet-number 7`.
+- That number was then matched as a text fragment rather than as a whole sheet number, so `--exclude-sheet-number 12` also excluded sheets 1 and 2.
+
+The more digits in the number, the more sheets were wrongly affected. A single one-digit number was always handled correctly. No other sheet filter was affected — `--exclude-sheet-status`, `--exclude-sheet-tag`, `--exclude-sheet-title`, `--blur-sheet-status` and `--blur-sheet-title` always worked as documented.
+
+**How to confirm from an old log:**
+
+At the default log level (`info`) Butler Sheet Icons logs one line per sheet it skipped or blurred, so a log from an earlier run tells you which sheets were affected:
+
+```
+Excluded sheet: 1: 'Sales overview', ...
+Using blurred thumbnail for sheet 1: ...
+```
+
+These lines say **that** a sheet was skipped or blurred, not **why** — status, tag and title filters produce the same lines. To see the reason, re-run with `--loglevel verbose`, which adds a line naming the filter that matched:
+
+```
+Excluded sheet (via sheet number): 1: 'Sales overview', ...
+Blurred sheet thumbnail (via sheet number): 1: 'Sales overview', ...
+```
+
+**Solutions:**
+
+1. **Upgrade to BSI 3.12.0 or later.** Both options now keep every number you list and match each as a whole sheet number.
+
+2. **Re-check your options before re-running.** If you worked around the old behaviour — listing sheet numbers one run at a time, or picking numbers that avoided the overlap — those workarounds are no longer needed and will now produce the wrong result.
+
+3. **Re-run thumbnail generation.** Nothing corrects itself: sheets that were wrongly excluded still have their old icons, and sheets that were wrongly blurred still have blurred ones, until Butler Sheet Icons runs again.
+
+See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers) for how the options behave now.
+
 ### Sheets Not Loading
 
 **Symptoms:**

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -93,6 +93,66 @@ In earlier versions this printed `Connection to tenant … successful.` followed
 
 **What to do:** verify `--tenanturl` points at a Qlik Sense Cloud tenant and that `--apikey` is valid and unexpired. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
 
+### `Failed to upload N of M thumbnail image(s)`
+
+Thumbnail images were generated but could not be uploaded, so **the app was left untouched** and its sheets keep the icons they already had.
+
+On Qlik Sense Cloud:
+
+```
+CLOUD APP (stack): CloudError: Failed to upload 2 of 5 thumbnail image(s) to Qlik Sense Cloud app abc-123
+```
+
+On Qlik Sense Enterprise on Windows the message names the content library instead:
+
+```
+QSEOW: qseowProcessApp (stack): QseowError: Failed to upload 2 of 5 thumbnail image(s) to content library BSI thumbnails
+```
+
+::: warning Requires BSI 3.12.0 or later
+In earlier versions the run carried on after a failed upload and repointed **every** sheet at an image that was not there, replacing working icons with broken ones — and reported no error. If apps are showing broken sheet icons from an earlier run, see "Repairing apps affected before upgrading" below.
+:::
+
+**What to do:**
+
+1. **Your sheets are safe.** Nothing in the app was changed, so its existing icons are intact. There is no cleanup to do.
+2. **Read the lines immediately above**, prefixed `CLOUD UPLOAD 1` or `QSEOW UPLOAD 1`. Those name the underlying reason — that is where the actual cause is. Common ones are an image larger than the tenant or server accepts, a content library that does not exist or that the account cannot write to, and network interruptions.
+3. **Fix the cause and re-run.** The command is safe to run again.
+
+Every image is attempted before the run stops, so one failure does not hide the others — the count tells you how widespread the problem is.
+
+#### Repairing apps affected before upgrading
+
+If earlier runs left apps showing broken sheet icons, re-running `create-sheet-thumbnails` against those apps repairs them, once the upload problem itself is resolved. To clear the icons instead of regenerating them, use `qscloud remove-sheet-icons` — note this exists only for Qlik Sense Cloud.
+
+### `TypeError: Cannot read properties of undefined (reading 'rank')`
+
+A single sheet missing its layout data caused the **whole app** to be abandoned before any thumbnail was created or removed. Every other sheet in that app was left untouched.
+
+::: warning Requires BSI 3.12.0 or later
+Fixed. Such sheets are now sorted to the end of the sheet list and processed like any other, so the app completes.
+:::
+
+Search your logs for `reading 'rank'` — that phrase is identical in every case. The text before it varies by platform and by how far the run had got:
+
+| Platform | Stage | Log line begins |
+| --- | --- | --- |
+| Qlik Sense Cloud | Creating thumbnails | `CLOUD APP (stack):` |
+| Qlik Sense Cloud | Applying thumbnails to sheets | `CLOUD UPDATE SHEETS (stack):` |
+| Qlik Sense Cloud | Removing sheet icons | `CLOUD REMOVE SHEET ICONS 1 (stack):` |
+| Enterprise on Windows | Creating thumbnails | `QSEOW: qseowProcessApp (stack):` |
+| Enterprise on Windows | Applying thumbnails to sheets | `QSEOW UPDATE SHEETS (stack):` |
+
+A closely related failure, `reading 'showCondition'`, is fixed by the same change and is worth searching for too. It struck slightly later — after thumbnails had been generated but before they were uploaded, so the work was still discarded.
+
+**What to do:** upgrade and re-run. The affected apps should now complete.
+
+**What causes it:** the sheet is missing its layout data — the part carrying its position in the app and its show condition. This comes from Qlik Sense rather than Butler Sheet Icons, and is uncommon. It has been seen with sheets that are partially created or partially deleted, and with sheets whose owner no longer exists. Such a sheet is now named in the log as it is processed, so you can still find it in Qlik Sense to repair or delete it.
+
+**One consequence to be aware of:** sheet numbers come from this sort order, so in an app containing such a sheet the numbering can differ from before — see [Sheet exclusion](/guide/concepts/sheet-exclusion) and [Sheet blurring](/guide/concepts/sheet-blurring).
+
+**Not covered by this fix:** a sheet missing its **title and description** — a different part of the sheet record — can still interrupt a run. That case is less common and is being addressed separately.
+
 ### The run failed — has anything changed in Qlik Sense?
 
 An app is saved once, after all of its sheets have been dealt with. If the run fails before that save, **nothing about the app changes** and its sheets keep the icons they had. Re-running is a clean retry, not a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -479,8 +479,8 @@ Creating thumbnails itself does not need internet access once a browser is avail
 2. **Browser Selection and Versions**:
 
    ```bash
-   # Try different browser
-   --browser firefox
+   # Thumbnails are rendered with Chrome only
+   --browser chrome
 
    # Use specific stable browser version
    butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
@@ -548,12 +548,8 @@ Creating thumbnails itself does not need internet access once a browser is avail
 3. **Browser Compatibility Testing**:
 
    ```bash
-   # Test with both Chrome and Firefox
-   # Chrome:
+   # Watch the run in a visible browser
    butler-sheet-icons qscloud create-sheet-icons --browser chrome --headless false ...
-
-   # Firefox:
-   butler-sheet-icons qscloud create-sheet-icons --browser firefox --headless false ...
    ```
 
 4. **SSO and Login Page Issues**:
@@ -599,12 +595,14 @@ Creating thumbnails itself does not need internet access once a browser is avail
    butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
    ```
 
-3. **Firefox as Alternative**:
+3. **Try a different Chrome build**:
    ```bash
-   # If Chrome versions have issues, try Firefox
-   butler-sheet-icons browser install --browser firefox
-   butler-sheet-icons qscloud create-sheet-icons --browser firefox ...
+   # If one Chrome build has issues, install and use another
+   butler-sheet-icons browser install --browser chrome --browser-version 120.0.6099.109
+   butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
    ```
+
+   Firefox is not an alternative here — it cannot render thumbnails. See [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Browser Cache and Permissions
 
@@ -928,8 +926,8 @@ See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-seve
 2. **Browser Settings**:
 
    ```bash
-   # Try different browser
-   --browser firefox
+   # Thumbnails are rendered with Chrome only
+   --browser chrome
 
    # Ensure browser is up to date
    butler-sheet-icons browser install --browser chrome

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -31,6 +31,72 @@ butler-sheet-icons qscloud create-sheet-icons --headless false
 butler-sheet-icons browser list-installed
 ```
 
+## Run Failures and Exit Codes
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions always exited with `0`. If your automation never reported a failure before upgrading, that is why — see [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status).
+:::
+
+An exit code of `1` means the run failed, or finished with apps it could not process. Butler Sheet Icons logs a reason. Match the message you see below.
+
+### `Failed to process N of M app(s)`
+
+Some apps in the run could not be processed. The other apps were still attempted — one bad app does not stop the rest — and this line is the summary at the end.
+
+Each failed app has its own line earlier in the log naming the cause:
+
+```
+CLOUD PROCESS APP: Failed to process app b: engine unreachable
+Failed to process 1 of 3 app(s)
+```
+
+**What to do:** find the per-app lines and treat each cause separately. They are ordinary failures — an unreachable engine, an app the account cannot write to, a published app — and are covered by the sections below.
+
+### `No apps to process`
+
+The options you supplied matched no apps at all. This is reported as a failure, not a silent success: work was requested and none happened.
+
+```
+No apps to process. Check the --appid and --collectionid options.
+```
+
+On Qlik Sense Enterprise on Windows the hint names `--appid` and `--qliksensetag` instead.
+
+**What to do:** check the selection options themselves. Common causes are a collection that exists but contains no apps, a tag that no app carries, or an app ID that has been deleted. On QS Cloud, `butler-sheet-icons qscloud list-collections` shows which collections exist.
+
+### `Failed to update N of M sheet(s) in app <id>`
+
+One or more sheets in an app could not be updated, or their icons could not be removed. The app is reported as failed, and therefore so is the run.
+
+```
+CLOUD UPDATE SHEETS: Failed to update sheet 1 ('Sales overview', ID abc-123) in app 97089caf: Sheet is read-only
+Failed to update 1 of 2 sheet(s) in app 97089caf
+```
+
+Every other sheet is still attempted first, and the engine session is always released — only at the end is the app reported as failed.
+
+**Reading the counts:** the number is of sheets Butler Sheet Icons **tried** to update. Sheets deliberately left alone — because you excluded them, or because no thumbnail was generated for them — are counted in neither figure. So "1 of 2" means two sheets were attempted and one failed, regardless of how many sheets the app has in total.
+
+The per-sheet line names the sheet by title and ID, which is what you need to find it in Qlik Sense. The number is the sheet's position in the app, counting from 1.
+
+**What to do:** open the named sheet. A read-only or published sheet cannot be updated by the account BSI is running as. See [App Access Issues](#app-access-issues).
+
+### `Connection test to tenant ... returned a response with no user in it`
+
+The Qlik Sense Cloud connection test reached something, but the response did not describe a user.
+
+```
+Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no user in it. Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.
+```
+
+In earlier versions this printed `Connection to tenant … successful.` followed by four lines reading `undefined`, and the run then failed later for reasons that looked unrelated.
+
+**What to do:** verify `--tenanturl` points at a Qlik Sense Cloud tenant and that `--apikey` is valid and unexpired. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
+
+### The run failed — has anything changed in Qlik Sense?
+
+An app is saved once, after all of its sheets have been dealt with. If the run fails before that save, **nothing about the app changes** and its sheets keep the icons they had. Re-running is a clean retry, not a resume. See [How it works](/guide/concepts/how-it-works#what-happens-at-each-step).
+
 ## Authentication Issues
 
 ### QS Cloud Authentication Problems

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -6,7 +6,7 @@ For details on how BSI decides which browser to use at runtime, and how environm
 
 ## Overview
 
-BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The browser command supports Chrome and Firefox across Windows, macOS, and Linux platforms.
+BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The `browser` command manages both Chrome and Firefox across Windows, macOS, and Linux. Note that only Chrome can render sheet thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ## Basic Usage
 
@@ -121,7 +121,7 @@ butler-sheet-icons browser install [options]
 | --------------------------------- | ------------------------------- | -------------------------------------------------------- | -------- | --------------------------------- |
 | `--loglevel, --log-level <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel debug`                |
 | `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install (chrome, firefox)                     | `chrome` | `--browser firefox`               |
-| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Specific version/build ID to install                     | `latest` | `--browser-version 121.0.6167.85` |
+| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Keyword (`recommended`, `stable`), channel, or build ID   | `recommended` | `--browser-version 121.0.6167.85` |
 | `-h, --help`                      | `-`                             | Display help for command                                 | `-`      | `--help`                          |
 
 **Examples:**
@@ -321,11 +321,12 @@ butler-sheet-icons qscloud create-sheet-thumbnails \
   --browser chrome \
   --browser-version 121.0.6167.85
 
-# Use Firefox for QSEoW
+# Pin a different Chrome build for QSEoW
 butler-sheet-icons qseow create-sheet-thumbnails \
   --host sense.company.com \
   --app-id "app-456" \
-  --browser firefox
+  --browser chrome \
+  --browser-version 120.0.6099.109
 ```
 
 ## Browser Cache Location

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -14,19 +14,21 @@ butler-sheet-icons <platform> <command> [options]
 
 ## Quick Reference
 
-| Platform  | Command                   | Purpose                              |
-| --------- | ------------------------- | ------------------------------------ |
-| `qscloud` | `create-sheet-icons`      | Create thumbnails for QS Cloud apps  |
-| `qscloud` | `remove-sheet-icons`      | Remove thumbnails from QS Cloud apps |
-| `qscloud` | `list-collections`        | List available collections           |
-| `qseow`   | `create-sheet-thumbnails` | Create thumbnails for QSEoW apps     |
-| `qseow`   | `create-sheet-icons`      | Alias of create-sheet-thumbnails     |
-| `qseow`   | `remove-sheet-icons`      | Remove thumbnails from QSEoW apps    |
-| `browser` | `install`                 | Install browser for BSI              |
-| `browser` | `list-installed`          | Show installed browsers              |
-| `browser` | `list-available`          | Show available browsers for download |
-| `browser` | `uninstall`               | Remove specific browser              |
-| `browser` | `uninstall-all`           | Remove all browsers                  |
+| Platform  | Command                   | Purpose                              | Alias                     |
+| --------- | ------------------------- | ------------------------------------ | ------------------------- |
+| `qscloud` | `create-sheet-thumbnails` | Create thumbnails for QS Cloud apps  | `create-sheet-icons`      |
+| `qscloud` | `remove-sheet-icons`      | Remove thumbnails from QS Cloud apps | `remove-sheet-thumbnails` |
+| `qscloud` | `list-collections`        | List available collections           | —                         |
+| `qseow`   | `create-sheet-thumbnails` | Create thumbnails for QSEoW apps     | `create-sheet-icons`      |
+| `browser` | `install`                 | Install browser for BSI              | —                         |
+| `browser` | `list-installed`          | Show installed browsers              | —                         |
+| `browser` | `list-available`          | Show available browsers for download | —                         |
+| `browser` | `uninstall`               | Remove specific browser              | —                         |
+| `browser` | `uninstall-all`           | Remove all browsers                  | —                         |
+
+::: warning No `remove-sheet-icons` on QSEoW
+Removing sheet icons is available for Qlik Sense Cloud only. There is no `qseow remove-sheet-icons` command — `create-sheet-thumbnails` is the only `qseow` command.
+:::
 
 ## Global Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -51,7 +51,7 @@ These options are available for most commands:
 
 ## Exit codes
 
-::: warning Requires BSI 3.12.0 or later
+::: warning Requires BSI 4.0.0 or later
 Earlier versions always exited with `0`, whatever happened during the run.
 :::
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -47,6 +47,31 @@ These options are available for most commands:
 - `debug` - Debug information
 - `silly` - Everything including websocket traffic
 
+## Exit codes
+
+::: warning Requires BSI 3.12.0 or later
+Earlier versions always exited with `0`, whatever happened during the run.
+:::
+
+Every command reports its outcome in the process exit code:
+
+| Exit code | Meaning                                                                       |
+| --------- | ----------------------------------------------------------------------------- |
+| `0`       | The command completed, and everything it was asked to do succeeded.           |
+| `1`       | The command failed, or finished with one or more apps it could not process.   |
+
+### What counts as a failure
+
+- **An app that could not be processed.** Other apps in the same run are still attempted — one bad app does not stop the rest — but the run reports failure at the end.
+- **A connection that could not be established** to the Qlik Sense server or Qlik Sense Cloud tenant.
+- **A selection that matched no apps at all**, for example a `--collectionid` that exists but contains no apps, or a `--qliksensetag` that no app carries. Work was requested and none happened, so this is a failure rather than a silent no-op.
+- **A sheet that could not be updated, or whose icon could not be removed.** The remaining sheets in that app are still attempted; the app is reported as failed at the end.
+- **A Qlik Sense Cloud connection test that returns a response containing no user.**
+
+If you run Butler Sheet Icons from a scheduled task, CI pipeline or shell script, read [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status) before upgrading — a job that always reported success may start reporting failure.
+
+For the log messages that accompany a non-zero exit code, see [Run failures and exit codes](/guide/troubleshooting#run-failures-and-exit-codes) in Troubleshooting.
+
 ## Detailed command references
 
 Use these pages for complete, per-platform command details:

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -35,8 +35,8 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--browser-page-timeout` | `BSI_BROWSER_PAGE_TIMEOUT`           | Seconds to wait for a page to load                  | `90`     | `--browser-page-timeout 120`      |
 | `--imagedir`             | `BSI_QSCLOUD_CST_IMAGE_DIR`          | Screenshot directory                                | `./img`  | `--imagedir ./screenshots`        |
 | `--includesheetpart`     | `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART` | Screenshot area (1 = content, 2 = +title, 4 = full) | `1`      | `--includesheetpart 2`            |
-| `--browser`              | `BSI_QSCLOUD_CST_BROWSER`            | Browser type                                        | `chrome` | `--browser firefox`               |
-| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser version                                     | `latest` | `--browser-version 121.0.6167.85` |
+| `--browser`              | `BSI_QSCLOUD_CST_BROWSER`            | Browser type (`chrome` only)                        | `chrome` | `--browser chrome`                |
+| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser version                                     | `recommended` | `--browser-version 121.0.6167.85` |
 | `--skip-login`           | `BSI_QSCLOUD_CST_SKIP_LOGIN`         | Skip login page                                     | `false`  | `--skip-login`                    |
 
 ### Sheet Filtering

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -58,6 +58,16 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--blur-sheet-status` | `BSI_QSCLOUD_CST_BLUR_SHEET_STATUS` | Blur by status          | `[]`    | `--blur-sheet-status published`       |
 | `--blur-factor`       | `BSI_QSCLOUD_CST_BLUR_FACTOR`       | Blur intensity (0-1000) | `5`     | `--blur-factor 10`                    |
 
+::: tip One sheet number per environment variable
+`BSI_QSCLOUD_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:
+
+```
+error: option '--exclude-sheet-number <number...>' value '1 2 12' from env 'BSI_QSCLOUD_CST_EXCLUDE_SHEET_NUMBER' is invalid. Exclude sheet number must be a non-negative integer.
+```
+
+To select several sheets, pass `--exclude-sheet-number` or `--blur-sheet-number` on the command line instead. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers).
+:::
+
 ### Complete Example
 
 ```bash

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -56,7 +56,7 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--blur-sheet-number` | `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` | Blur by position        |         | `--blur-sheet-number 2 4`             |
 | `--blur-sheet-title`  | `BSI_QSCLOUD_CST_BLUR_SHEET_TITLE`  | Blur by title           |         | `--blur-sheet-title "Financial Data"` |
 | `--blur-sheet-status` | `BSI_QSCLOUD_CST_BLUR_SHEET_STATUS` | Blur by status          | `[]`    | `--blur-sheet-status published`       |
-| `--blur-factor`       | `BSI_QSCLOUD_CST_BLUR_FACTOR`       | Blur intensity (0-1000) | `5`     | `--blur-factor 10`                    |
+| `--blur-factor`       | `BSI_QSCLOUD_CST_BLUR_FACTOR`       | Blur intensity (1-100)  | `5`     | `--blur-factor 10`                    |
 
 ::: tip One sheet number per environment variable
 `BSI_QSCLOUD_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSCLOUD_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -103,7 +103,7 @@ butler-sheet-icons qseow create-sheet-thumbnails \
   --contentlibrary "Butler sheet thumbnails" \
   --sense-version 2024-May \
   --browser chrome \
-  --browser-version latest \
+  --browser-version recommended \
   --secure true \
   --includesheetpart 2 \
   --browser-page-timeout 120 \

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -76,7 +76,7 @@ butler-sheet-icons qseow create-sheet-thumbnails [options]
 | `--blur-sheet-title`  | `BSI_QSEOW_CST_BLUR_SHEET_TITLE`  | Blur by title          |         | `--blur-sheet-title "Financial Data"` |
 | `--blur-sheet-status` | `BSI_QSEOW_CST_BLUR_SHEET_STATUS` | Blur by status         | `[]`    | `--blur-sheet-status published`       |
 | `--blur-sheet-tag`    | `BSI_QSEOW_CST_BLUR_SHEET_TAG`    | Blur by tag            |         | `--blur-sheet-tag "sensitive"`        |
-| `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (0-100) | `5`     | `--blur-factor 10`                    |
+| `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (1-100) | `5`     | `--blur-factor 10`                    |
 
 ::: tip One sheet number per environment variable
 `BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSEOW_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -78,6 +78,16 @@ butler-sheet-icons qseow create-sheet-thumbnails [options]
 | `--blur-sheet-tag`    | `BSI_QSEOW_CST_BLUR_SHEET_TAG`    | Blur by tag            |         | `--blur-sheet-tag "sensitive"`        |
 | `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (0-100) | `5`     | `--blur-factor 10`                    |
 
+::: tip One sheet number per environment variable
+`BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSEOW_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:
+
+```
+error: option '--exclude-sheet-number <number...>' value '1 2 12' from env 'BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER' is invalid. Exclude sheet number must be a non-negative integer.
+```
+
+To select several sheets, pass `--exclude-sheet-number` or `--blur-sheet-number` on the command line instead. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers).
+:::
+
 ### Example: create thumbnails
 
 ```bash

--- a/docs/reference/supported-versions.md
+++ b/docs/reference/supported-versions.md
@@ -122,9 +122,9 @@ butler-sheet-icons qscloud create-sheet-icons \
   --browser chrome \
   --browser-version 121.0.6167.85
 
-# Use Firefox (latest only)
-butler-sheet-icons qscloud create-sheet-icons --browser firefox
 ```
+
+Chrome is the only browser accepted by the thumbnail commands — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Browser Management
 


### PR DESCRIPTION
## Description

Release merge for **Butler Sheet Icons 4.0.0**, published as `butler-sheet-icons-v4.0.0`.

Step 1 of the procedure in `README_DEPLOY.md` is satisfied — BSI was released first, so `releases/latest` already points at 4.0.0 and the nav version label will pick it up on this build.

### What goes live

| Area | Content |
| --- | --- |
| Sheet number selection | `--exclude-sheet-number` / `--blur-sheet-number` were matching the wrong sheets before 4.0.0. New section on `/guide/concepts/sheet-exclusion`, a warning on `/guide/concepts/sheet-blurring`, a troubleshooting entry, and the single-value environment variable rule on both reference pages (#44) |
| `--blur-factor` | The site gave three different ranges and two different defaults. Now one correct answer everywhere: range 1–100, default 5, values above 100 silently capped (#45, closes #43) |
| Version gates | 19 gates across 8 pages named 3.12.0, a version that does not exist. All corrected to 4.0.0 (#46) |
| Firefox | 4.0.0 rejects `--browser firefox` on the thumbnail commands. Nine command examples and five descriptions across seven pages would have failed for anyone on 4.0.0 (#47) |

### Why the version gates said 3.12.0

The drafts were written while release-please PR ptarmiganlabs/butler-sheet-icons#774 was titled `chore(main): release butler-sheet-icons 3.12.0`. Two breaking changes landed before it merged — the `--browser firefox` removal and the exit code change — so the bump was recomputed as a major.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [x] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

`/guide/concepts/sheet-exclusion`, `/guide/concepts/sheet-blurring`, `/guide/concepts/browser-management`, `/guide/concepts/browser-detection-and-environment-variables`, `/guide/concepts/how-it-works`, `/guide/troubleshooting`, `/guide/advanced/ci-cd`, `/guide/configuration/qseow`, `/guide/configuration/qlik-sense-cloud`, `/examples/browser-management`, `/reference/qseow`, `/reference/qscloud`, `/reference/browser`, `/reference/commands`, `/reference/supported-versions`.

## Checklist

- [x] This PR targets `main` — deliberate: this is the release merge, per `README_DEPLOY.md`
- [x] `npm run docs:build` passes locally
- [x] Internal links are absolute and extensionless
- [x] New pages have a sidebar entry — n/a, no new pages in this cycle
- [x] Images display correctly and have descriptive alt text
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Notes for reviewers

**Post-merge step that is not in this repo:** `BSI_DOCS_VERSION` on the Cloudflare **preview** environment still points at the old upcoming version. It does not update itself and cannot be changed from here — set it to the next upcoming version or clear it in the Cloudflare dashboard, per step 4 of the release procedure. Production is unaffected; the override is preview-only.

**Still pending in the BSI staging folder,** unreviewed and not in this release: `browser-version-selection.md`, `log-messages-name-the-right-operation.md`, `qrs-tag-names-with-special-characters.md`, `docker-image-directory-permissions-on-linux.md`. The first documents 4.0.0's new browser-version vocabulary, so parts of `/reference/browser` remain stale until it is processed — stale, but not breaking.
