### PR TITLE
docs: publish browser build selection guidance

### DIFF
--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -125,15 +125,108 @@ butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version
 
 If you instead want to force BSI to use a _system_ browser (for example a centrally managed Chrome or Edge installation), set `PUPPETEER_EXECUTABLE_PATH` before running BSI. This is described in detail on the [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables) page.
 
-## Browser Versions and Compatibility
+## Choosing a browser build
 
-### Chrome Versions
+`--browser-version` decides which browser build Butler Sheet Icons uses. It accepts a keyword, a release channel, or an exact build id.
 
-Chrome versions use build numbers (e.g., `121.0.6167.85`). Butler Sheet Icons supports:
+### The two keywords
 
-- **Latest stable**: Always recommended for most users
-- **Specific versions**: Useful for environments requiring consistency
-- **Multiple channels**: Stable, beta, dev, canary (though stable is recommended)
+| Value | Meaning | How the build is decided |
+| --- | --- | --- |
+| `recommended` | The build this version of Butler Sheet Icons was tested with. **This is the default.** | Fixed inside Butler Sheet Icons |
+| `stable` | The newest stable release of the browser. | Looked up online, every time the command runs |
+
+Both work for Chrome and Firefox, so you do not need to know what each vendor calls its channels.
+
+**`recommended` is the right choice for almost everyone.** It cannot get ahead of what Butler Sheet Icons is able to drive, and it changes only when you upgrade Butler Sheet Icons itself. That gives you two things:
+
+- **Every server on the same Butler Sheet Icons version uses the same browser build.** A fleet of scheduled jobs cannot drift apart on its own.
+- **No lookup at run time.** The build id is baked in, so once it is cached there is nothing to ask the vendor. With `stable`, every run first asks which build is currently newest.
+
+Choose `stable` only if you specifically need the newest stable release — for example because a security policy requires it. Be aware that it follows whatever the vendor has promoted, which can be a build newer than Butler Sheet Icons has been tested against.
+
+Release **channels** are also accepted, and like `stable` they are resolved at run time: `beta`, `dev` and `canary` for Chrome; `beta`, `nightly`, `devedition` and `esr` for Firefox.
+
+::: tip A browser is never bundled with Butler Sheet Icons
+Whichever value you use, the browser is downloaded once and then kept in the local cache, so the first run on a new server always needs internet access. The keywords differ only in *how the build id is decided* — which is what matters on a server that is offline afterwards. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables).
+:::
+
+### Naming an exact build
+
+You can pin an exact build. The format is checked before anything else happens, so a typo stops the run immediately with a message naming the accepted forms — it is never silently swapped for another build from the cache.
+
+For **Chrome**, three forms are accepted:
+
+| Form | Example | Selects |
+| --- | --- | --- |
+| Milestone | `151` | The newest build of milestone 151 |
+| Build prefix | `151.0.7922` | The newest patch of that build |
+| Full build id | `151.0.7922.77` | Exactly that build |
+
+For **Firefox**, the build id must carry its channel prefix, for example `stable_153.0.3`. A bare version such as `152.0.1` is rejected: without the prefix it would be read as a nightly build, which is almost never what you want.
+
+To see what can be installed:
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons.exe browser list-available --browser chrome
+```
+
+```bash [Bash]
+./butler-sheet-icons browser list-available --browser chrome
+```
+
+:::
+
+### If you currently use `latest`
+
+::: warning `latest` changed meaning in BSI 4.0.0
+`latest` still works — no scripts or scheduled tasks need editing — but it is now treated as `stable`, and the run logs two lines the first time it is used:
+
+```
+warn: --browser-version "latest" now means "stable" - the newest stable release of the browser.
+warn: It previously meant the newest published build, which could be one the browser automation library cannot drive. Use "recommended" for the build Butler Sheet Icons is tested against, or "stable" to keep tracking the newest stable release.
+```
+
+The old meaning — the newest *published* build — is what caused runs to fail against a browser Butler Sheet Icons could not drive, so it is no longer available. For the safest behaviour, drop the option and let the default apply, or set it to `recommended` explicitly. See [Every app fails with `Target closed` or `Protocol error`](/guide/troubleshooting#every-app-fails-with-target-closed-or-protocol-error).
+:::
+
+### What to expect on the first run after upgrading
+
+Butler Sheet Icons matches a cached browser by exact build. On the first run after upgrading, most servers download the recommended build, because what they have cached is whatever `latest` happened to fetch previously. This is a one-time download per server, and it is what puts every server on the same known-good build.
+
+To do it ahead of time rather than during a scheduled run:
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons.exe browser install --browser chrome
+```
+
+```bash [Bash]
+./butler-sheet-icons browser install --browser chrome
+```
+
+:::
+
+You can then remove the old build. List what is installed, then name the exact build to remove:
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons.exe browser list-installed
+butler-sheet-icons.exe browser uninstall --browser chrome --browser-version <build id from the list>
+```
+
+```bash [Bash]
+./butler-sheet-icons browser list-installed
+./butler-sheet-icons browser uninstall --browser chrome --browser-version <build id from the list>
+```
+
+:::
+
+`browser uninstall` accepts an exact build id, or `recommended`. It deliberately does **not** accept `stable`, `latest` or a channel: those name whatever the vendor currently publishes, not a build on your machine, so they cannot safely identify something to delete. Uninstalling never needs internet access.
 
 ### Firefox Versions
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -837,6 +837,50 @@ export https_proxy=https://username:password@proxy.company.com:8080
 export http_proxy=http://user:pass@proxy.company.com:8080
 ```
 
+## Browser Build Issues
+
+### Every app fails with `Target closed` or `Protocol error`
+
+**Symptoms:**
+
+- Every app in the run fails, not just one
+- Errors mention `TargetCloseError`, `Protocol error`, `Target closed` or `Session closed`
+- The same job works on one server and fails on another with identical configuration
+
+```
+error: CLOUD APP (stack): TargetCloseError: Protocol error (Browser.getVersion): Target closed
+error: Failed to process 2 of 2 app(s)
+```
+
+**Cause:**
+
+The Chrome build being used cannot be driven by Butler Sheet Icons. Before BSI 4.0.0 the default was `latest`, meaning the newest *published* Chrome build — and Chrome ships new builds continuously, so that was sometimes a build the browser automation library could not control. Two servers could behave differently purely because each had a different build sitting in its cache.
+
+**Solutions:**
+
+1. **Use the recommended build**, which is the default from BSI 4.0.0 onward. Either remove `--browser-version` entirely or set it explicitly:
+
+   ```bash
+   --browser-version recommended
+   ```
+
+   From 4.0.0, Butler Sheet Icons also detects this itself and says so directly, naming the build instead of leaving you with a protocol error:
+
+   ```
+   error: QSEOW: Browser build 151.0.7922.109 started but stopped responding immediately. This build cannot be driven by Butler Sheet Icons.
+   error: Use a different browser build: "--browser-version recommended" selects the build Butler Sheet Icons is tested with. The same value can be set via the command's BSI_*_BROWSER_VERSION environment variable.
+   ```
+
+2. **Check for a `BSI_*_BROWSER_VERSION` environment variable** overriding your command line. A scheduled job or unit file may still set `latest`.
+
+3. **Install the recommended build ahead of time** so it is not downloaded during a scheduled run:
+
+   ```bash
+   butler-sheet-icons browser install --browser chrome
+   ```
+
+See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build) for what each keyword selects.
+
 ## Sheet-Specific Issues
 
 ### Sheets you did not select were skipped or blurred

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -102,12 +102,12 @@ error: Butler Sheet Icons needs internet access for this command. If this machin
        available locally.
 ```
 
-Use `browser list-installed` instead to see what is already available locally. For Firefox, the command makes no network call — it simply reports that `latest` is the only supported version.
+Use `browser list-installed` instead to see what is already available locally.
 :::
 
 ### install
 
-Downloads and installs a browser into the BSI cache. By default, installs the latest stable version of Chrome.
+Downloads and installs a browser into the BSI cache. By default, installs the Chrome build Butler Sheet Icons is tested with (`recommended`).
 
 **Usage:**
 
@@ -148,16 +148,11 @@ Install latest Firefox (macOS):
 
 #### Browser Version Notes
 
-**Chrome Versions:**
+**Chrome:** a milestone (`151`), a build prefix (`151.0.7922`) or a full build id (`151.0.7922.77`). Some older builds may no longer be downloadable — use `list-available` to see what is currently offered.
 
-- Chrome supports specific build IDs (e.g., `121.0.6167.85`)
-- Some older Chrome versions may no longer be available for download
-- Use `list-available` to see what versions are currently downloadable
+**Firefox:** a channel-prefixed build id such as `stable_153.0.3`. A bare version number is rejected, because it would be interpreted as a nightly build.
 
-**Firefox Versions:**
-
-- Currently, only the `latest` version of Firefox is supported
-- Specific version support for Firefox is pending
+Both also accept the keywords `recommended` and `stable`, and a release channel. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
 
 ::: warning Older Chrome Versions
 If you try to install an older Chrome version that's no longer available, you'll get a 404 error. The Chrome team periodically removes older versions from their download servers. Use a newer version instead.
@@ -183,7 +178,7 @@ butler-sheet-icons browser uninstall [options]
 | --------------------------------- | -------------------------------- | -------------------------------------------------------- | -------- | --------------------------------- |
 | `--loglevel, --log-level <level>` | `BSI_BROWSER_UI_LOG_LEVEL`       | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel warn`                 |
 | `--browser <browser>`             | `BSI_BROWSER_UI_BROWSER`         | Browser to uninstall (chrome, firefox)                   | `chrome` | `--browser firefox`               |
-| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Specific version/build ID to uninstall                   | `-`      | `--browser-version 121.0.6167.85` |
+| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Exact build id, or `recommended`. Not `stable`/`latest`. | `-`      | `--browser-version 121.0.6167.85` |
 | `-h, --help`                      | `-`                              | Display help for command                                 | `-`      | `--help`                          |
 
 **Example (Windows):**

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -36,8 +36,12 @@ butler-sheet-icons qscloud create-sheet-icons [options]
 | `--imagedir`             | `BSI_QSCLOUD_CST_IMAGE_DIR`          | Screenshot directory                                | `./img`  | `--imagedir ./screenshots`        |
 | `--includesheetpart`     | `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART` | Screenshot area (1 = content, 2 = +title, 4 = full) | `1`      | `--includesheetpart 2`            |
 | `--browser`              | `BSI_QSCLOUD_CST_BROWSER`            | Browser type (`chrome` only)                        | `chrome` | `--browser chrome`                |
-| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser version                                     | `recommended` | `--browser-version 121.0.6167.85` |
+| `--browser-version`      | `BSI_QSCLOUD_CST_BROWSER_VERSION`    | Browser build to use                                | `recommended` | `--browser-version stable`        |
 | `--skip-login`           | `BSI_QSCLOUD_CST_SKIP_LOGIN`         | Skip login page                                     | `false`  | `--skip-login`                    |
+
+::: tip Which browser build?
+`--browser-version` accepts `recommended` (the build Butler Sheet Icons is tested with, and the default), `stable`, a release channel, or an exact build id. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
+:::
 
 ### Sheet Filtering
 

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -56,6 +56,8 @@ butler-sheet-icons qseow create-sheet-thumbnails [options]
 | `--pagewait`             | `BSI_QSEOW_CST_PAGE_WAIT`          | Seconds to wait per sheet          | `5`                       | `--pagewait 6`                               |
 | `--browser-page-timeout` | `BSI_BROWSER_PAGE_TIMEOUT`         | Seconds to wait for a page to load | `90`                      | `--browser-page-timeout 120`                 |
 | `--imagedir`             | `BSI_QSEOW_CST_IMAGE_DIR`          | Screenshot directory               | `./img`                   | `--imagedir ./img`                           |
+| `--browser`              | `BSI_QSEOW_CST_BROWSER`            | Browser type (`chrome` only)       | `chrome`                  | `--browser chrome`                           |
+| `--browser-version`      | `BSI_QSEOW_CST_BROWSER_VERSION`    | Browser build to use               | `recommended`             | `--browser-version stable`                   |
 
 ### Sheet filtering
 
@@ -86,6 +88,10 @@ error: option '--exclude-sheet-number <number...>' value '1 2 12' from env 'BSI_
 ```
 
 To select several sheets, pass `--exclude-sheet-number` or `--blur-sheet-number` on the command line instead. See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers).
+:::
+
+::: tip Which browser build?
+`--browser-version` accepts `recommended` (the build Butler Sheet Icons is tested with, and the default), `stable`, a release channel, or an exact build id. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
 :::
 
 ### Example: create thumbnails


### PR DESCRIPTION
## Description

Publishes the browser build selection documentation to production.

Unlike the previous release merge, there is no version gate to wait for: Butler Sheet Icons 4.0.0 is already released, so this content describes the current release rather than an upcoming one.

Single change over `main` — butler-sheet-icons-docs#49, reviewed and approved on the `next` preview.

BSI 4.0.0 replaced the `--browser-version` default. It used to be `latest`, meaning the newest *published* browser build, which is how a build the automation library could not drive got selected in the first place — and why the same scheduled job could work on one server and fail on another with identical configuration. The default is now `recommended`: the build this BSI release is tested against, fixed inside BSI rather than looked up at run time.

## Type of change

- [ ] Fix (typo, broken link, incorrect information)
- [x] Content update (new information or examples on an existing page)
- [ ] New page
- [x] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

| Page | What changed |
| --- | --- |
| `/guide/concepts/browser-management` | New "Choosing a browser build" section — the two keywords and when each is right, release channels, exact build formats per browser, the `latest` change, and what to expect on the first run after upgrading |
| `/guide/troubleshooting` | New "Every app fails with `Target closed` or `Protocol error`" entry, keyed on the symptom rather than the version |
| `/reference/browser` | Corrected the `install` default and the version-format guidance; narrowed the `uninstall` `--browser-version` description |
| `/reference/qseow` | Added `--browser` and `--browser-version` rows, which the table did not previously have |
| `/reference/qscloud` | Corrected the `--browser-version` description |

## Checklist

- [x] This PR targets `main` — deliberate: this is the release merge, per `README_DEPLOY.md`
- [x] `npm run docs:build` passes locally
- [x] Internal links are absolute and extensionless
- [x] New pages have a sidebar entry — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [x] Checked the Cloudflare Pages preview link — reviewed and approved on `next.butler-sheet-icons-docs.pages.dev`

Both new anchors verified against the generated HTML, since the build does not validate fragments.

## Notes for reviewers

**`BSI_DOCS_VERSION` on the Cloudflare preview environment is still outstanding** from the 4.0.0 release merge (#48). It does not update itself and cannot be changed from this repo — set it to the next upcoming version or clear it in the Cloudflare dashboard. Production is unaffected; the override is preview-only.

**Three drafts remain unprocessed** in the BSI staging folder, none of them blocking: `log-messages-name-the-right-operation.md`, `qrs-tag-names-with-special-characters.md`, `docker-image-directory-permissions-on-linux.md`.

**Known follow-up:** what happens when a `stable` lookup fails on an offline machine is not documented. BSI degrades to the newest cached build with a warning for floating keywords, and never degrades when the input was invalid. It belongs with the existing offline material on `/guide/concepts/browser-detection-and-environment-variables`.
