### PR TITLE
docs: publish the QRS name, Docker and log message fixes

### DIFF
--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -1,10 +1,5 @@
 # Docker Usage
 
-docker run --rm ptarmiganlabs/butler-sheet-icons:latest --help
-docker run --rm \
-docker run --rm `docker run --rm \
-docker run --rm`
-docker run --rm \
 Butler Sheet Icons (BSI) is available as an official Docker image, making it easy to run in containers or orchestrators.
 
 - Image: `ptarmiganlabs/butler-sheet-icons:latest`
@@ -15,3 +10,57 @@ Butler Sheet Icons (BSI) is available as an official Docker image, making it eas
 For details on how the container decides which browser to use, and how to override the embedded browser with a cached or system browser, see [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables).
 
 For concrete container commands (including QS Cloud, QSEoW, volume mounts, and docker-compose), see the dedicated [Docker Examples](/examples/docker) page.
+
+## Writing thumbnails to a mounted folder on Linux
+
+The way to get thumbnails out of the container is to mount a folder from the host:
+
+```bash
+docker run -it --rm \
+  -v "$HOME/bsi/img:/nodeapp/img" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  qseow create-sheet-thumbnails \
+  --imagedir ./img \
+  ...
+```
+
+::: warning Requires BSI 4.0.0 or later on Linux hosts
+In earlier versions this failed on a Linux host, for **every** app in the run. Butler Sheet Icons runs inside the container as a dedicated unprivileged account, and that account did not own the folder you mounted — your own account did — so it could not create anything in it.
+
+From 4.0.0 the container looks at who owns the folder you mounted and runs as that user. **Nothing about your command changes**, and thumbnails now belong to you on the host rather than to an account that exists only inside the container.
+
+See [Permission denied writing thumbnails from the Docker image](/guide/troubleshooting#permission-denied-writing-thumbnails-from-the-docker-image) if you hit this before upgrading.
+:::
+
+This only ever affected Linux. Docker Desktop on macOS and Windows ignores file ownership on mounted folders, so the same command worked on a laptop and failed on a Linux server — which is exactly where scheduled runs live.
+
+When the container adapts to the folder's owner, it says so once, before anything else:
+
+```
+butler-sheet-icons: running as uid 1000:1000, adopted from /nodeapp/img, so files written there belong to you
+```
+
+If that line is absent, the container is running as its own built-in account. That is correct and expected when you have not mounted anything, or when the mounted folder already belongs to that account.
+
+### Cases the container cannot adapt to
+
+Three situations remain where it still cannot write. Each now explains itself in the log rather than failing with a bare permission error.
+
+**The mounted folder is owned by `root`.** Butler Sheet Icons deliberately does not adopt root's identity to work around this — running a browser and processing untrusted content as root is not a worthwhile trade. Mount a folder you own instead:
+
+```bash
+mkdir -p "$HOME/bsi/img"
+```
+
+**You started the container with an explicit `--user`.** That instruction is respected as given, so it is up to you to ensure the account you named can write to the folder:
+
+```bash
+docker run -it --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$HOME/bsi/img:/nodeapp/img" \
+  ...
+```
+
+This form is fully supported, and is the right choice where a security policy fixes the container's user in advance. From 4.0.0 it also works correctly for the persistent browser cache, which it did not before.
+
+**The folder is mounted read-only.** A mount ending in `:ro` cannot be written to by anyone. Remove the flag from the folder that receives thumbnails.

--- a/docs/guide/concepts/sheet-exclusion.md
+++ b/docs/guide/concepts/sheet-exclusion.md
@@ -24,6 +24,22 @@ QSEoW only:
 - --exclude-sheet-tag <value...>
   Exclude sheets that have one or more specified tags (set in QMC > App objects). Tags don’t exist for individual sheets in QS Cloud.
 
+::: danger Several exclude tags matched nothing before BSI 4.0.0
+Giving two or more tags — `--exclude-sheet-tag "Finance" "HR"` — did not exclude anything. Butler Sheet Icons joined them into the single name `Finance,HR` and asked Qlik Sense for sheets carrying a tag with that exact name. No such tag exists, so nothing matched and **every sheet had its icon updated**, including the ones you had tagged to keep out.
+
+There was no error and no warning; the run looked completely normal. A single `--exclude-sheet-tag` was not affected by this.
+
+**If you use two or more exclude tags, review those apps.** From 4.0.0 sheets carrying **any** of the tags are excluded, which is what the option always described — but icons already replaced are not restored automatically, because Butler Sheet Icons has no record of what they were. Re-run once the exclusions work, or set those sheet icons back by hand.
+:::
+
+::: warning Punctuation in tag and content library names — BSI 4.0.0 or later
+Before 4.0.0, a name containing `&`, `'`, `#`, `?`, `/` or `%` was sent to Qlik Sense unprotected, and the lookup failed outright. This affected `--qliksensetag`, `--exclude-sheet-tag` and `--contentlibrary`.
+
+Names such as `R&D`, `Q1'25`, `Finance/HR` or `Sprint #4` now work, quoted on the command line exactly as any other name containing spaces. If you renamed a tag to work around this — `R&D` to `RandD` — you can rename it back, remembering to update the option or environment variable that names it.
+
+See [Tag or content library name fails or matches nothing](/guide/troubleshooting#tag-or-content-library-name-fails-or-matches-nothing) for the errors each character produced.
+:::
+
 Example parameters usage:
 
 ```bash

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -837,6 +837,35 @@ export https_proxy=https://username:password@proxy.company.com:8080
 export http_proxy=http://user:pass@proxy.company.com:8080
 ```
 
+### Tag or content library name fails or matches nothing
+
+**Symptoms:**
+
+- A QSEoW run fails immediately with a `400` or `403` from Qlik Sense
+- Or it completes normally but excludes nothing, even though the tags are set in the QMC
+
+**Cause:**
+
+Before BSI 4.0.0, names supplied to `--qliksensetag`, `--exclude-sheet-tag` and `--contentlibrary` were sent to the Qlik Sense Repository Service unprotected, so punctuation in a name was read as instructions rather than as part of the name. Each character failed in its own way:
+
+| Character in the name | What you saw |
+| --- | --- |
+| `&` | `400::Missing parameter value(s)` |
+| `'` | `400::Cannot parse the expression:` followed by the query |
+| `#` | `403::XSRF prevention check failed. Possible XSRF discovered.` |
+| `?` or `/` | `Request path contains unescaped characters` |
+| `%` | `URI malformed` |
+
+Names containing `+`, `=` or `,` were unaffected, as were names made only of letters, digits, spaces, hyphens and underscores.
+
+Separately — and silently — giving **two or more** `--exclude-sheet-tag` values joined them into one name, so nothing matched and every sheet was updated. See [Sheet Exclusion](/guide/concepts/sheet-exclusion#exclusion-options).
+
+**Solutions:**
+
+1. **Upgrade to BSI 4.0.0 or later.** Names are now protected before being sent, and several exclude tags match any of them.
+2. **Review apps where you used two or more exclude tags.** Sheets you meant to exclude have been getting new icons on every run. Re-run once exclusions work, or restore those icons by hand.
+3. **Undo any renaming workaround.** If you renamed `R&D` to `RandD`, you can rename it back — update the matching option or environment variable at the same time.
+
 ## Browser Build Issues
 
 ### Every app fails with `Target closed` or `Protocol error`
@@ -976,6 +1005,77 @@ See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-seve
    # Ensure browser is up to date
    butler-sheet-icons browser install --browser chrome
    ```
+
+## Docker Issues
+
+### Permission denied writing thumbnails from the Docker image
+
+**Symptoms:**
+
+- Running the Docker image on a **Linux** host, every app in the run fails
+- The log contains `EACCES`
+- The same command works on a macOS or Windows laptop
+
+```
+error: EACCES: permission denied, mkdir './img/cloud/6ab8a5b7-1f0e-4e9c-8b53-9f42b6c1a0d2'
+error: CLOUD PROCESS APP: Failed to process app 6ab8a5b7-1f0e-4e9c-8b53-9f42b6c1a0d2: Error creating cloud image directory
+```
+
+On QSEoW the wording differs slightly — `QSEOW CREATE THUMBNAILS 1` in place of `CLOUD PROCESS APP`, and `qseow` in place of `cloud` in the path — but `EACCES` appears either way. Search your logs for `EACCES`.
+
+A QSEoW **certificate** failure has the same underlying cause. If you mounted a folder holding `client.pem` and `client_key.pem` and saw this even though the files were plainly there, this is why — certificate files are normally readable only by their owner:
+
+```
+error: QSEOW CREATE THUMBNAILS 2: Missing certificate file(s)
+```
+
+**Cause:**
+
+Before BSI 4.0.0, the container ran as a built-in unprivileged account that did not own the folder you mounted. Docker Desktop on macOS and Windows ignores ownership on mounted folders, so this only ever showed up on Linux — which is where scheduled runs live.
+
+**Solutions:**
+
+1. **Upgrade to BSI 4.0.0 or later and re-run.** No change to your command is needed. The container adopts the mounted folder's owner and logs one line when it does:
+
+   ```
+   butler-sheet-icons: running as uid 1000:1000, adopted from /nodeapp/img, so files written there belong to you
+   ```
+
+2. **Do not mount a `root`-owned folder.** The container deliberately will not run as root. Mount one you own instead.
+
+3. **If you pass `--user` explicitly**, that is respected as given — make sure the account you name can write to the folder.
+
+4. **Check for a `:ro` mount.** A read-only mount cannot receive thumbnails.
+
+See [Docker Usage](/guide/advanced/docker#writing-thumbnails-to-a-mounted-folder-on-linux) for the full explanation.
+
+## Reading the Logs
+
+### Log messages changed in BSI 4.0.0
+
+Several log lines named the wrong operation, or were punctuated inconsistently between platforms. Nothing about how Butler Sheet Icons behaves changed — only what it writes. **This matters if you have log monitoring that matches on the old text.**
+
+| Command | Old text | New text |
+| --- | --- | --- |
+| `qscloud remove-sheet-icons` | `Closed session after updating sheet thumbnail images in QS Cloud app …` | `Closed session after removing sheet icons in QS Cloud app …` |
+| `qscloud remove-sheet-icons` | `CLOUD PROCESS APP 2: Failed to process app …` | `CLOUD REMOVE SHEET ICONS: Failed to process app …` |
+
+Neither "updating" nor "generating" describes removing an icon, and the `2` was a leftover that did not name the command actually running.
+
+A failure to start the built-in browser used to be punctuated differently per platform — QS Cloud used a colon after the prefix, QSEoW did not. Both now use the colon:
+
+```
+CLOUD APP: Could not launch virtual browser: …
+QSEOW: Could not launch virtual browser: …
+```
+
+**One line is new at the default log level.** Running `qscloud remove-sheet-icons`, this was written at `verbose` and so was hidden at the default `info`:
+
+```
+Created session to <server or tenant>, engine version is <version>
+```
+
+It is now written at `info`, matching every other command that works on an app you named. Expect one extra line per app; use `--loglevel warn` to suppress it along with the other progress messages. Commands that re-open an app already announced by the step above them still log at `verbose`, so no app is announced twice in one run.
 
 ## Platform-Specific Issues
 

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -80,6 +80,10 @@ butler-sheet-icons qseow create-sheet-thumbnails [options]
 | `--blur-sheet-tag`    | `BSI_QSEOW_CST_BLUR_SHEET_TAG`    | Blur by tag            |         | `--blur-sheet-tag "sensitive"`        |
 | `--blur-factor`       | `BSI_QSEOW_CST_BLUR_FACTOR`       | Blur intensity (1-100) | `5`     | `--blur-factor 10`                    |
 
+::: tip Names with punctuation
+`--qliksensetag`, `--exclude-sheet-tag` and `--contentlibrary` accept names containing `&`, `'`, `#`, `?`, `/` and `%` from BSI 4.0.0 onward — `R&D` or `Q1'25` need no special quoting beyond the usual for spaces. Earlier versions failed on these. Giving several `--exclude-sheet-tag` values excludes sheets carrying **any** of them; before 4.0.0 it matched nothing at all. See [Tag or content library name fails or matches nothing](/guide/troubleshooting#tag-or-content-library-name-fails-or-matches-nothing).
+:::
+
 ::: tip One sheet number per environment variable
 `BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` and `BSI_QSEOW_CST_BLUR_SHEET_NUMBER` each hold a **single** sheet number. A value containing more than one number is rejected at startup:
 


### PR DESCRIPTION
## Description

Publishes the last three staged drafts to production. 4.0.0 is already released, so this describes the current release and there is no gate to wait for.

Single change over `main` — butler-sheet-icons-docs#51, reviewed and approved on the `next` preview.

**This empties the staging folder.** Every draft in `ptarmiganlabs/butler-sheet-icons` `docs/to-doc-site/` has now been processed into `done/`.

The most consequential item: before 4.0.0, giving two or more `--exclude-sheet-tag` values joined them into a single tag name, matched nothing, and updated **every** sheet — including the ones tagged to keep out. Silently, with the run reporting success.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [x] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

| Page | What changed |
| --- | --- |
| `/guide/concepts/sheet-exclusion` | `danger` callout for the several-exclude-tags bug with what to check and re-run; `warning` callout for punctuation in tag and content library names |
| `/guide/troubleshooting` | Three new entries — "Tag or content library name fails or matches nothing", "Permission denied writing thumbnails from the Docker image" (new Docker Issues section), and "Log messages changed in BSI 4.0.0" (new Reading the Logs section) |
| `/guide/advanced/docker` | New "Writing thumbnails to a mounted folder on Linux" section; also removes five orphaned code fragments that had been rendering as stray text at the top of the page |
| `/reference/qseow` | "Names with punctuation" tip on sheet filtering |

## Checklist

- [x] This PR targets `main` — deliberate: this is the release merge, per `README_DEPLOY.md`
- [x] `npm run docs:build` passes locally
- [x] Internal links are absolute and extensionless
- [x] New pages have a sidebar entry — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [x] Checked the Cloudflare Pages preview link — reviewed and approved on the `next` preview

All five new anchor targets were verified against the generated HTML, since the build does not validate fragments.

## Notes for reviewers

**`BSI_DOCS_VERSION` on the Cloudflare preview environment is still outstanding**, carried over from #48. It does not update itself and cannot be changed from this repo. Production is unaffected — the override is preview-only.

**One known documentation gap remains**, not from any draft: what happens when a `stable` browser-version lookup fails on an offline machine. BSI degrades to the newest cached build with a warning for floating keywords, and never degrades when the input was invalid.
