### PR TITLE
docs: explain what --browser-version costs on an offline machine

### DIFF
--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -85,7 +85,9 @@ If the environment has no internet access and no browser can be found via steps 
 
 ## Which browser commands need internet access?
 
-Creating thumbnails does not need internet access for the browser itself, as long as step 1 or step 2 above finds one. The `browser` management commands are different — only some of them reach out to the internet:
+Creating thumbnails does not need internet access for the browser itself, as long as step 1 or step 2 above finds one — **but the value of `--browser-version` decides whether the run needs a lookup before it gets that far.** See [What `--browser-version` costs on an offline machine](#what-browser-version-costs-on-an-offline-machine) below.
+
+The `browser` management commands are different — only some of them reach out to the internet:
 
 | Command                              | Needs internet? |
 | ------------------------------------ | --------------- |
@@ -115,6 +117,40 @@ Setting `PUPPETEER_EXECUTABLE_PATH` to a browser installed by other means works 
 
 ::: warning Requires BSI 4.0.0 or later
 Earlier versions reported a failed `browser list-available` on an offline machine as a raw stack trace (`TypeError: Cannot read properties of undefined (reading 'status')`) with line numbers from inside the BSI binary — nothing an administrator could act on. From 4.0.0 the messages above are shown instead.
+:::
+
+## What `--browser-version` costs on an offline machine
+
+A thumbnail run has to turn `--browser-version` into a specific build before it can look in the cache. Some values need the browser vendor's version service to do that, and some do not — which is the difference between a run that works offline and one that depends on connectivity every time.
+
+| Value | Needs a lookup? |
+| --- | --- |
+| `recommended` (the default) | **No.** The build id is a constant inside Butler Sheet Icons. |
+| `stable`, `latest`, or a channel such as `beta` | **Yes**, on every run. These mean "whatever the vendor currently publishes", which can only be answered by asking. |
+| An exact full build id, e.g. `151.0.7922.77` | **No.** Already specific. |
+| A milestone or build prefix, e.g. `151` or `151.0.7922` | **Yes.** Butler Sheet Icons has to ask which build that resolves to. |
+
+**This is the strongest practical argument for `recommended` on an air-gapped or proxied machine.** It is the only value that is both current for your Butler Sheet Icons version and free of a per-run lookup.
+
+### When the lookup fails
+
+What happens next depends on how specific you were.
+
+**A floating keyword degrades to the cache.** For `stable`, `latest` and the release channels, a failed lookup is treated as an environment problem rather than a mistake. Butler Sheet Icons warns twice and carries on with the newest cached build of the right browser:
+
+```
+warn: Could not resolve --browser-version "stable": <reason>
+warn: Falling back to the newest browser already in the local cache.
+```
+
+If nothing is cached either, there is nothing to fall back to and the original lookup error is reported instead.
+
+**A pin does not degrade.** If you named a milestone or a build prefix and the lookup fails, the run stops. Asking for `151` is a promise about which build runs, and quietly substituting a different cached build would be the very thing that made runs fail unpredictably before 4.0.0 — a build nobody chose, selected silently.
+
+**Bad input never degrades.** A malformed version or an unsupported browser is your input being wrong, so it is reported as an error whether or not something is cached.
+
+::: tip Getting a genuinely offline run
+Use `recommended` (or simply omit `--browser-version`) and pre-populate the cache with `browser install` while the machine still has connectivity. That combination needs the network exactly once, on the machine that prepares the cache. See [Strategy 3](#strategy-3-use-a-pre-cached-browser-semi-offline) and [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
 :::
 
 ## Key environment variables

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -145,6 +145,8 @@ Both work for Chrome and Firefox, so you do not need to know what each vendor ca
 
 Choose `stable` only if you specifically need the newest stable release — for example because a security policy requires it. Be aware that it follows whatever the vendor has promoted, which can be a build newer than Butler Sheet Icons has been tested against.
 
+It also means a lookup on every run: on an offline or proxied machine that costs you connectivity you may not have. See [What `--browser-version` costs on an offline machine](/guide/concepts/browser-detection-and-environment-variables#what-browser-version-costs-on-an-offline-machine).
+
 Release **channels** are also accepted, and like `stable` they are resolved at run time: `beta`, `dev` and `canary` for Chrome; `beta`, `nightly`, `devedition` and `esr` for Firefox.
 
 ::: tip A browser is never bundled with Butler Sheet Icons

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -102,7 +102,7 @@ error: Butler Sheet Icons needs internet access for this command. If this machin
        available locally.
 ```
 
-Use `browser list-installed` instead to see what is already available locally.
+Use `browser list-installed` instead to see what is already available locally. For Firefox the command makes no network call at all — it reports that only the latest version is supported and returns.
 :::
 
 ### install


### PR DESCRIPTION
## Description

**Not from a staged draft** — the staging folder is empty. This closes the one documentation gap I flagged while publishing the browser-version work (butler-sheet-icons-docs#49) and again in #51.

The site said thumbnail creation needs no internet access for the browser once one is cached. True as far as it goes, but it skips the step before that: turning `--browser-version` into a specific build. `stable`, `latest` and the release channels mean "whatever the vendor currently publishes", which can only be answered by asking — on every run. So can a milestone or a build prefix.

| Value | Needs a lookup? |
| --- | --- |
| `recommended` (the default) | **No** — the build id is a constant inside BSI |
| `stable`, `latest`, a channel | **Yes**, every run |
| Full build id, `151.0.7922.77` | **No** — already specific |
| Milestone or prefix, `151` / `151.0.7922` | **Yes** |

That is the strongest practical argument for `recommended` on an air-gapped or proxied machine, and it was nowhere on the site.

## Type of change

- [ ] Fix (typo, broken link, incorrect information)
- [x] Content update (new information or examples on an existing page)
- [x] Enhancement (clearer explanation, reorganisation)
- [ ] New page
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

| Page | What changed |
| --- | --- |
| `/guide/concepts/browser-detection-and-environment-variables` | New "What `--browser-version` costs on an offline machine" section — the lookup table above, what happens when the lookup fails, and a tip on getting a genuinely offline run. The existing "Which browser commands need internet access?" section now points at it |
| `/guide/concepts/browser-management` | The `stable` paragraph now notes the per-run lookup cost and links to the new section |
| `/reference/browser` | Restores a sentence dropped in an earlier pass — see below |

## Failure behaviour, which is the part that is easy to get wrong

Verified in `browser-launch.js` and `browser-version.js`:

- **A floating keyword degrades to the cache.** `stable`, `latest` and the channels warn twice and carry on with the newest cached build of the right browser. If nothing is cached, the original lookup error is reported instead.
- **A pin does not degrade.** A milestone or build prefix whose lookup fails stops the run. Substituting a different cached build would be exactly the silent-wrong-build failure that 4.0.0 set out to end.
- **Bad input never degrades**, cached browser or not.

## Correction to my own earlier work

An earlier pass (#47) removed this from `/reference/browser`:

> For Firefox, the command makes no network call — it simply reports that `latest` is the only supported version.

That removal was wrong. `browser list-available` still short-circuits Firefox with a "support is not implemented yet" warning and no network call, whatever `browser install` now accepts. Restored, with wording that ties it to `list-available` specifically.

## Notes for reviewers

With this merged, I am not aware of any remaining inaccuracy or known gap on the site.

Separately, and **not a documentation matter**: nothing in the render path uses Firefox at all any more, so a Firefox installed through `browser install` can never be used by Butler Sheet Icons for anything. Worth deciding upstream whether that surface should stay.
