### PR TITLE
build: read the preview version label from release-please

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -121,7 +121,7 @@ document different releases:
 | Build | Source | Why |
 | --- | --- | --- |
 | Production (`main`) | Latest GitHub release, tag normalised (`butler-sheet-icons-v4.0.0` → `v4.0.0`) | Production documents the release that has shipped |
-| Preview (any other branch) | The version in `.release-please-manifest.json` on the open release-please pull request's branch | `next` documents a release that is not out yet, so the latest release would label it with the *previous* version |
+| Preview (any other branch) | The version in `.release-please-manifest.json` on release-please's release branch | `next` documents a release that is not out yet, so the latest release would label it with the *previous* version |
 | Local (`npm run docs:dev`) | Latest GitHub release | `CF_PAGES_BRANCH` is unset outside Cloudflare |
 
 **Do not try to set the upcoming version by hand.** It is not knowable in advance and

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -72,7 +72,7 @@ once checks pass.
 
 ### At release time
 
-Order matters, because the version label in the site nav follows the **latest GitHub
+Order matters, because the version label on production follows the **latest GitHub
 release** of Butler Sheet Icons (see "Version label" below):
 
 1. Release Butler Sheet Icons first, so `releases/latest` points at the new version.
@@ -80,8 +80,9 @@ release** of Butler Sheet Icons (see "Version label" below):
    requires a pull request for `main` — direct pushes and force pushes are rejected —
    though no approvals are required, so you can merge your own.
 3. Cloudflare publishes; the nav label picks up the new version on that build.
-4. Update `BSI_DOCS_VERSION` on the Cloudflare **preview** environment to the next
-   upcoming version, or clear it. It does not update itself.
+
+There is no manual version step. The `next` preview reads its label from
+release-please, and production reads the latest release, so both correct themselves.
 
 Merging before the BSI release ships puts new content on the site under the *old*
 version number for however long the gap lasts.
@@ -110,21 +111,35 @@ a GitHub check rather than only as a failed Cloudflare deployment.
 
 The version shown in the site's top nav is **cosmetic**. It gates no content.
 
-`scripts/fetch-bsi-version.mjs` runs before every dev/build, asks the GitHub API for the
-latest `ptarmiganlabs/butler-sheet-icons` release, normalises the tag
-(`butler-sheet-icons-v3.11.0` → `v3.11.0`), and writes `docs/.vitepress/version.js`.
-That file is git-ignored and regenerated on each build. `docs/.vitepress/config.js`
-imports it and uses the string as a nav dropdown label.
+`scripts/fetch-bsi-version.mjs` runs before every dev/build and writes
+`docs/.vitepress/version.js`. That file is git-ignored and regenerated on each build.
+`docs/.vitepress/config.js` imports it and uses the string as a nav dropdown label.
 
-Two environment variables affect this:
+Which version it picks depends on what is being built, because `main` and `next`
+document different releases:
+
+| Build | Source | Why |
+| --- | --- | --- |
+| Production (`main`) | Latest GitHub release, tag normalised (`butler-sheet-icons-v4.0.0` → `v4.0.0`) | Production documents the release that has shipped |
+| Preview (any other branch) | The version in `.release-please-manifest.json` on the open release-please pull request's branch | `next` documents a release that is not out yet, so the latest release would label it with the *previous* version |
+| Local (`npm run docs:dev`) | Latest GitHub release | `CF_PAGES_BRANCH` is unset outside Cloudflare |
+
+**Do not try to set the upcoming version by hand.** It is not knowable in advance and
+not stable once guessed: release-please recomputes the bump as commits land and retitles
+the same pull request. A release tracking 3.12.0 became 4.0.0 that way when two breaking
+changes arrived, after several pages had already been written against 3.12.0. Reading it
+per build is what makes the label self-correcting.
+
+Every lookup degrades rather than failing the build: pending version → latest release →
+the previously generated `version.js` → `v0.0.0`.
+
+Environment variables that affect this:
 
 | Variable | Where | Effect |
 | --- | --- | --- |
-| `GITHUB_TOKEN` (or `GH_TOKEN`) | Cloudflare project, CI, local | Authenticates the API call. **Recommended in Cloudflare.** Build IPs are shared, so the 60 req/hour anonymous limit is reachable; because `version.js` is git-ignored, a fresh build container has no previous file to fall back on and the nav silently renders `v0.0.0`. |
-| `BSI_DOCS_VERSION` | Cloudflare **preview** environment | Overrides the lookup entirely. Set it to the upcoming version (e.g. `v3.12.0`) so the `next` preview is labelled with the version it actually documents rather than the last released one. Leave it unset on production. |
-
-Cloudflare supports separate production and preview environment variables, which is what
-makes the `BSI_DOCS_VERSION` split work.
+| `GITHUB_TOKEN` (or `GH_TOKEN`) | Cloudflare project, CI, local | Authenticates the API calls. **Recommended in Cloudflare.** Build IPs are shared, so the 60 req/hour anonymous limit is reachable; because `version.js` is git-ignored, a fresh build container has no previous file to fall back on and the nav silently renders `v0.0.0`. |
+| `CF_PAGES_BRANCH` | Set by Cloudflare Pages | Read, not set by us. Decides production vs preview behaviour above. |
+| `BSI_DOCS_VERSION` | Anywhere | **Escape hatch, normally unset.** Overrides everything and never falls back. Only useful to pin a label the automation cannot work out. A stale value here silently defeats the automation. |
 
 ## Settings that live in Cloudflare, not in this repo
 
@@ -133,7 +148,7 @@ under Workers & Pages → `butler-sheet-icons-docs`:
 
 - **Production branch** — must be `main`.
 - **Preview deployments** — must include `next` (the default is all non-production branches). If set to "None", `next` gets no preview URL and the branch model has no staging site.
-- **Environment variables** — `GITHUB_TOKEN` on production and preview; `BSI_DOCS_VERSION` on preview only.
+- **Environment variables** — `GITHUB_TOKEN` on production and preview. `BSI_DOCS_VERSION` should be **unset** on both; it is an escape hatch, and a leftover value silently overrides the automatic version label.
 - **Custom domain** — `butler-sheet-icons.ptarmiganlabs.com` is attached here. It is *not* controlled by a `CNAME` file in the repo; that is a GitHub Pages mechanism and was removed.
 - **Access policy on preview URLs** — preview deployments are publicly reachable by default. They are unlinked and not indexed, but guessable. If unreleased documentation must not be readable by anyone who finds the URL, put Cloudflare Access in front of preview deployments.
 
@@ -160,7 +175,7 @@ Export `GITHUB_TOKEN` locally to avoid anonymous API rate limits on the version 
 | Symptom | Cause / action |
 | --- | --- |
 | Nav shows `v0.0.0` | Version lookup failed and no cached file existed. Set `GITHUB_TOKEN` in the Cloudflare project. |
-| Nav shows the wrong version on a `next` preview | Expected without `BSI_DOCS_VERSION`; the lookup returns the latest *released* version. Set the override on the preview environment. |
+| Nav shows the wrong version on a `next` preview | Check the build log for the `[bsi-docs]` lines. They name the branch, whether it was treated as a preview, and which release PR was read. A stale `BSI_DOCS_VERSION` overriding everything is the most likely cause. |
 | Change not live on production | Check the "Cloudflare Pages" check run on the commit. Confirm the commit is on `main`, not `next`. |
 | Build fails on a dead link | VitePress names the offending file and link. Internal links are absolute and extensionless: `/guide/concepts/browser-management`. |
 | Anchor link goes nowhere | Anchors are not build-validated. Several pages use a non-breaking hyphen `‑` (U+2011) in headings, which survives into the generated id. Normalise headings to ASCII hyphens. |

--- a/scripts/fetch-bsi-version.mjs
+++ b/scripts/fetch-bsi-version.mjs
@@ -10,7 +10,7 @@
  *   - `next` documents a release that is not out yet, so the latest release would
  *     label it with the *previous* version. Instead we ask release-please what the
  *     next version is going to be, by reading `.release-please-manifest.json` from
- *     its open release pull request.
+ *     its release branch.
  *
  * Asking release-please matters because the upcoming version is not knowable in
  * advance and is not stable once guessed: release-please recomputes the bump as
@@ -30,8 +30,19 @@ const REPO = "butler-sheet-icons";
 const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
 const LATEST_RELEASE_URL = `${API_ROOT}/releases/latest`;
 
-/** Head-branch prefix release-please uses for its release pull requests. */
-const RELEASE_PR_BRANCH_PREFIX = "release-please--";
+/**
+ * Branch release-please keeps its pending release on. The name is derived from its
+ * config — `release-please--branches--<target>--components--<component>` — and is
+ * stable for as long as that config is.
+ *
+ * Read directly rather than found by listing open pull requests, because that would
+ * cost a second API call on every preview build. Anonymous builds share Cloudflare's
+ * IPs against a 60 req/hour limit, so halving the calls is worth the coupling: if the
+ * branch is ever renamed this 404s, which is handled as "no pending release" and falls
+ * through to the latest release.
+ */
+const RELEASE_BRANCH =
+  "release-please--branches--main--components--butler-sheet-icons";
 
 /**
  * Key in `.release-please-manifest.json` for the root component, i.e. Butler Sheet
@@ -77,8 +88,9 @@ function buildHeaders() {
   return headers;
 }
 
-async function getJson(url) {
+async function getJson(url, { nullOn404 = false } = {}) {
   const res = await fetch(url, { headers: buildHeaders() });
+  if (res.status === 404 && nullOn404) return null;
   if (!res.ok) {
     throw new Error(`GitHub API failed with ${res.status} ${res.statusText}`);
   }
@@ -101,26 +113,22 @@ function isPreviewBuild() {
 /**
  * Asks release-please what the next version will be.
  *
- * Reads the manifest from the open release pull request's branch rather than parsing
- * the PR title: the manifest is structured, and the title is prose that has changed
- * format before.
+ * Reads the manifest rather than parsing the release pull request's title: the manifest
+ * is structured, and the title is prose that has changed format before.
  *
  * @returns {Promise<string|null>} Version prefixed with 'v', or null when there is no
- * open release pull request — which is the normal state just after a release ships.
+ * pending release — the normal state just after a release ships, and also what a renamed
+ * release branch looks like from here.
  */
 async function fetchPendingReleaseVersion() {
-  const pulls = await getJson(`${API_ROOT}/pulls?state=open&per_page=100`);
-  const releasePr = pulls.find((pr) =>
-    pr?.head?.ref?.startsWith(RELEASE_PR_BRANCH_PREFIX)
-  );
-
-  if (!releasePr) return null;
-
   const manifest = await getJson(
     `${API_ROOT}/contents/.release-please-manifest.json?ref=${encodeURIComponent(
-      releasePr.head.ref
-    )}`
+      RELEASE_BRANCH
+    )}`,
+    { nullOn404: true }
   );
+
+  if (manifest === null) return null;
 
   if (typeof manifest?.content !== "string") {
     throw new Error("Release manifest response carried no content");
@@ -137,9 +145,7 @@ async function fetchPendingReleaseVersion() {
     );
   }
 
-  console.log(
-    `[bsi-docs] Release PR #${releasePr.number} targets ${version}`
-  );
+  console.log(`[bsi-docs] Pending release on ${RELEASE_BRANCH}: ${version}`);
 
   return `v${version}`;
 }
@@ -193,7 +199,7 @@ async function main() {
         return;
       }
       console.log(
-        "[bsi-docs] No open release PR; using the latest release instead"
+        "[bsi-docs] No pending release; using the latest release instead"
       );
     } catch (err) {
       console.warn(

--- a/scripts/fetch-bsi-version.mjs
+++ b/scripts/fetch-bsi-version.mjs
@@ -1,12 +1,25 @@
 /**
- * Fetch latest Butler Sheet Icons release tag and write to docs/.vitepress/version.js
- * This runs before docs:dev and docs:build. If the request fails, we keep the last
- * generated file (if any) and continue, so docs still build.
+ * Fetch the Butler Sheet Icons version to show in the site nav and write it to
+ * docs/.vitepress/version.js. This runs before docs:dev and docs:build. If a lookup
+ * fails, we keep the last generated file (if any) and continue, so docs still build.
  *
- * Set BSI_DOCS_VERSION to override the lookup entirely. The `next` branch documents
- * a BSI release that is not out yet, so its Cloudflare preview would otherwise be
- * labelled with the *previous* version. Set BSI_DOCS_VERSION on the preview
- * environment to the upcoming version instead. See README_DEPLOY.md.
+ * Which version is "right" depends on what is being built:
+ *
+ *   - `main` is production and documents the current release, so it uses the latest
+ *     GitHub release.
+ *   - `next` documents a release that is not out yet, so the latest release would
+ *     label it with the *previous* version. Instead we ask release-please what the
+ *     next version is going to be, by reading `.release-please-manifest.json` from
+ *     its open release pull request.
+ *
+ * Asking release-please matters because the upcoming version is not knowable in
+ * advance and is not stable once guessed: release-please recomputes the bump as
+ * commits land, and retitles the same pull request. A 3.12.0 release became 4.0.0
+ * that way once two breaking changes arrived, after several doc pages had already
+ * been written against 3.12.0. Reading it per build means the label corrects itself.
+ *
+ * Set BSI_DOCS_VERSION to override everything below. It is an escape hatch, not the
+ * normal path — see README_DEPLOY.md.
  */
 
 import fs from "node:fs/promises";
@@ -14,7 +27,22 @@ import path from "node:path";
 
 const OWNER = "ptarmiganlabs";
 const REPO = "butler-sheet-icons";
-const API_URL = `https://api.github.com/repos/${OWNER}/${REPO}/releases/latest`;
+const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
+const LATEST_RELEASE_URL = `${API_ROOT}/releases/latest`;
+
+/** Head-branch prefix release-please uses for its release pull requests. */
+const RELEASE_PR_BRANCH_PREFIX = "release-please--";
+
+/**
+ * Key in `.release-please-manifest.json` for the root component, i.e. Butler Sheet
+ * Icons itself. The file also carries `"src"`, which tracks separately and is not
+ * the product version.
+ */
+const MANIFEST_ROOT_COMPONENT = ".";
+
+/** Cloudflare Pages production branch. Anything else is a preview build. */
+const PRODUCTION_BRANCH = "main";
+
 const outFile = path.resolve("./docs/.vitepress/version.js");
 
 async function ensureDirExists(filePath) {
@@ -32,8 +60,116 @@ function isValidTag(tag) {
   return typeof tag === "string" && tag.trim().length > 0;
 }
 
+/** Normalize a release tag: keep from the first 'v' on, so 'x-v3.8.0' -> 'v3.8.0'. */
+function normalizeTag(rawTag) {
+  const vIndex = rawTag.indexOf("v");
+  return vIndex >= 0 ? rawTag.slice(vIndex) : rawTag;
+}
+
+function buildHeaders() {
+  const headers = { "User-Agent": "bsi-docs-build-script" };
+  // Use a token if provided. Build IPs are shared, so the anonymous limit is reachable.
+  const token =
+    process.env.GITHUB_TOKEN ||
+    process.env.GH_TOKEN ||
+    process.env.GITHUB_AUTH_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+async function getJson(url) {
+  const res = await fetch(url, { headers: buildHeaders() });
+  if (!res.ok) {
+    throw new Error(`GitHub API failed with ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+/**
+ * The branch being built, as reported by Cloudflare Pages. Unset locally, which is
+ * why local builds fall through to the latest release rather than the pending one.
+ */
+function currentBranch() {
+  return process.env.CF_PAGES_BRANCH?.trim() || "";
+}
+
+function isPreviewBuild() {
+  const branch = currentBranch();
+  return branch !== "" && branch !== PRODUCTION_BRANCH;
+}
+
+/**
+ * Asks release-please what the next version will be.
+ *
+ * Reads the manifest from the open release pull request's branch rather than parsing
+ * the PR title: the manifest is structured, and the title is prose that has changed
+ * format before.
+ *
+ * @returns {Promise<string|null>} Version prefixed with 'v', or null when there is no
+ * open release pull request — which is the normal state just after a release ships.
+ */
+async function fetchPendingReleaseVersion() {
+  const pulls = await getJson(`${API_ROOT}/pulls?state=open&per_page=100`);
+  const releasePr = pulls.find((pr) =>
+    pr?.head?.ref?.startsWith(RELEASE_PR_BRANCH_PREFIX)
+  );
+
+  if (!releasePr) return null;
+
+  const manifest = await getJson(
+    `${API_ROOT}/contents/.release-please-manifest.json?ref=${encodeURIComponent(
+      releasePr.head.ref
+    )}`
+  );
+
+  if (typeof manifest?.content !== "string") {
+    throw new Error("Release manifest response carried no content");
+  }
+
+  const parsed = JSON.parse(
+    Buffer.from(manifest.content, "base64").toString("utf8")
+  );
+  const version = parsed?.[MANIFEST_ROOT_COMPONENT];
+
+  if (!isValidTag(version)) {
+    throw new Error(
+      `Release manifest has no usable "${MANIFEST_ROOT_COMPONENT}" version`
+    );
+  }
+
+  console.log(
+    `[bsi-docs] Release PR #${releasePr.number} targets ${version}`
+  );
+
+  return `v${version}`;
+}
+
+async function fetchLatestReleaseVersion() {
+  const data = await getJson(LATEST_RELEASE_URL);
+  const rawTag = data.tag_name;
+  if (!isValidTag(rawTag)) {
+    throw new Error("Invalid tag_name in GitHub API response");
+  }
+  return normalizeTag(rawTag);
+}
+
+/** Keeps a previously generated file if there is one, otherwise writes a safe default. */
+async function writeFallbackVersion() {
+  try {
+    const existing = await fs.readFile(outFile, "utf8");
+    if (existing) {
+      console.log("[bsi-docs] Using existing generated version.js");
+      return;
+    }
+  } catch {}
+
+  const fallback = "v0.0.0";
+  await writeVersionFile(fallback);
+  console.log(`[bsi-docs] Wrote fallback version ${fallback}`);
+}
+
 async function main() {
-  // An explicit override wins over the API lookup, and never falls back.
+  // An explicit override wins over every lookup, and never falls back.
   const override = process.env.BSI_DOCS_VERSION?.trim();
   if (override) {
     await writeVersionFile(override);
@@ -41,46 +177,40 @@ async function main() {
     return;
   }
 
+  const branch = currentBranch();
+  console.log(
+    `[bsi-docs] Branch: ${branch || "(not a Cloudflare build)"}, preview: ${isPreviewBuild()}`
+  );
+
+  // Preview builds document the release that is coming, not the one that shipped.
+  // A failure here is not fatal: fall through to the latest release below.
+  if (isPreviewBuild()) {
+    try {
+      const pending = await fetchPendingReleaseVersion();
+      if (pending) {
+        await writeVersionFile(pending);
+        console.log(`[bsi-docs] Using pending release version: ${pending}`);
+        return;
+      }
+      console.log(
+        "[bsi-docs] No open release PR; using the latest release instead"
+      );
+    } catch (err) {
+      console.warn(
+        `[bsi-docs] Warning: Could not read the pending release version: ${err.message}`
+      );
+    }
+  }
+
   try {
-    const headers = { "User-Agent": "bsi-docs-build-script" };
-    // Use token if provided to avoid rate limiting
-    const token =
-      process.env.GITHUB_TOKEN ||
-      process.env.GH_TOKEN ||
-      process.env.GITHUB_AUTH_TOKEN;
-    if (token) headers.Authorization = `Bearer ${token}`;
-
-    const res = await fetch(API_URL, { headers });
-    if (!res.ok) {
-      throw new Error(`GitHub API failed with ${res.status} ${res.statusText}`);
-    }
-    const data = await res.json();
-    const rawTag = data.tag_name;
-    if (!isValidTag(rawTag)) {
-      throw new Error("Invalid tag_name in GitHub API response");
-    }
-
-    // Normalize: keep from first 'v' onwards (e.g., 'butler-sheet-icons-v3.8.0' -> 'v3.8.0')
-    const vIndex = rawTag.indexOf("v");
-    const tag = vIndex >= 0 ? rawTag.slice(vIndex) : rawTag;
-
+    const tag = await fetchLatestReleaseVersion();
     await writeVersionFile(tag);
     console.log(`[bsi-docs] Latest ${REPO} version: ${tag}`);
   } catch (err) {
     console.warn(
       `[bsi-docs] Warning: Could not fetch latest release tag: ${err.message}`
     );
-    // If the file already exists, keep it. Otherwise write a safe default.
-    try {
-      const existing = await fs.readFile(outFile, "utf8");
-      if (existing) {
-        console.log("[bsi-docs] Using existing generated version.js");
-        return;
-      }
-    } catch {}
-    const fallback = "v0.0.0";
-    await writeVersionFile(fallback);
-    console.log(`[bsi-docs] Wrote fallback version ${fallback}`);
+    await writeFallbackVersion();
   }
 }
 


### PR DESCRIPTION
## Description

Replaces the manual `BSI_DOCS_VERSION` preview label with a lookup against release-please. Relates to #37.

Setting the upcoming version by hand never worked well: it is not knowable in advance, and not stable once guessed. Release-please recomputes the bump as commits land and **retitles the same pull request** — a release tracking 3.12.0 became 4.0.0 that way once two breaking changes arrived, after several pages had already been written against 3.12.0. It also had to be bumped every release, from the Cloudflare dashboard, invisibly from this repo.

So ask release-please per build instead. On a preview build, find the open PR whose head branch starts with `release-please--`, read `.release-please-manifest.json` from that branch, and take the root component's version.

Reading the manifest rather than parsing the PR title is deliberate: the manifest is structured JSON, the title is prose that has changed format before. Note the manifest also carries `"src"`, which tracks separately and is **not** the product version — the root key `"."` is the one to read.

## Behaviour

| Build | Source | Unchanged? |
| --- | --- | --- |
| Production (`main`) | Latest GitHub release | Yes — identical to today |
| Preview (`next`, feature branches) | Version from the open release-please PR | New |
| Local (`npm run docs:dev`) | Latest GitHub release | Yes — `CF_PAGES_BRANCH` is unset outside Cloudflare |
| `BSI_DOCS_VERSION` set | That value | Yes — still wins over everything |

## Verified against the live repo

Not reasoned about — actually run, with the real GitHub API. There is an open release PR (ptarmiganlabs/butler-sheet-icons#926, targeting 4.0.1), which made every path testable:

| Scenario | Result |
| --- | --- |
| `CF_PAGES_BRANCH=next` | `Release PR #926 targets 4.0.1` → `v4.0.1` |
| `CF_PAGES_BRANCH=main` | `v4.0.0` (latest release, no PR lookup) |
| No `CF_PAGES_BRANCH` (local) | `v4.0.0` |
| `BSI_DOCS_VERSION=v9.9.9` on a preview | `v9.9.9`, no lookups |
| Preview, invalid token | Both lookups warn, keeps the existing `version.js`, **exit 0** |
| Preview, no network, no prior file | Both lookups warn, writes `v0.0.0`, **exit 0** |

The degradation chain is pending version → latest release → previously generated `version.js` → `v0.0.0`. No path fails the build.

## Type of change

- [ ] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [x] Repository/tooling change (config, workflows, dependencies)

## Pages affected

None — no site content changes. The only user-visible effect is the version label on preview deployments.

## Checklist

- [x] This PR targets `next`
- [x] `npm run docs:build` passes locally
- [x] Internal links are absolute and extensionless — n/a
- [x] New pages have a sidebar entry — n/a
- [x] Images display correctly and have descriptive alt text — n/a
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Action needed in the Cloudflare dashboard

**`BSI_DOCS_VERSION` must be cleared from the Preview environment**, or it will keep overriding this and the automation will look broken. It currently holds a stale value from before 4.0.0 shipped. It stays supported as an escape hatch, but should normally be unset.

`GITHUB_TOKEN` is still needed, and slightly more so — preview builds now make two API calls instead of one. That half of #37 stands.

Because a leftover override is the most likely way this silently misbehaves, the script now logs the branch it saw, whether it treated the build as a preview, and which release PR it read. The first preview deploy of this branch is also the check that Cloudflare really does expose `CF_PAGES_BRANCH` — if the log line reads `(not a Cloudflare build)`, that assumption is wrong and the preview will simply fall back to the latest release rather than break.

## Also updated

`README_DEPLOY.md`: step 4 is gone from the release procedure, the version-label section describes the new precedence and explains why hand-setting the version does not work, and the troubleshooting row now points at the build log.
