### PR TITLE
docs: correct how an external browser is used in the Docker image

### DIFF
--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -225,54 +225,102 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 ## Docker usage
 
-Browsers in Docker are downloaded inside the container.
+**The Docker image already contains a browser, and the `browser` commands are not how you manage it.**
 
-::: code-group
+Chromium is installed inside the image, and the image is configured to use it. This is deliberate: it is what lets the container run on a server with no internet access. See [Air-gapped environments](/guide/advanced/docker#air-gapped-environments).
 
-```bash [macOS/Linux]
-# List browsers in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
+### What to expect
 
-# Install a specific Chrome build in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
+`browser list-installed` reports nothing when run against the image:
 
-# Use that build for sheet icons
-docker run -it --rm \
-  -v $(pwd)/images:/nodeapp/img \
+```bash
+docker run --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
+```
+
+```
+info: No browsers installed
+```
+
+**This is correct, not a fault.** That command lists browsers Butler Sheet Icons downloaded and cached for itself. The browser in the image is a system package installed when the image was built, so it does not appear there.
+
+To see which browser the container will actually use:
+
+```bash
+docker run --rm --entrypoint /usr/bin/chromium-browser \
+  ptarmiganlabs/butler-sheet-icons:latest --version
+```
+
+```
+Chromium 150.0.7871.181 Alpine Linux
+```
+
+### `--browser-version` has no effect inside the image
+
+Passing `--browser-version` to a thumbnail command in the container does not change which browser runs. Butler Sheet Icons uses the embedded one and tells you it has done so:
+
+```
+warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.
+```
+
+Worse, on a machine without internet access, some values of `--browser-version` will make the run **fail** while still not changing the browser — because the version has to be resolved before the browser is chosen. Leave it at its default, `recommended`, when running in Docker. The reasoning is in [Browser versions on an air-gapped host](/guide/advanced/docker#browser-versions-on-an-air-gapped-host).
+
+### If you need a different browser build
+
+`browser install` on its own achieves nothing here: in a `--rm` container the download lands somewhere that is deleted seconds later. Using a browser other than the embedded one takes three things together, and leaving out any one of them breaks the run.
+
+**1. Put a browser in a folder on the host that the container can see.** Mount the folder and run `browser install` _inside the container_, so the browser that gets downloaded is a Linux build — which is what a Linux container can run. This step needs internet access:
+
+```bash
+mkdir -p "$HOME/bsi/browser-cache"
+
+docker run --rm \
+  -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
   ptarmiganlabs/butler-sheet-icons:latest \
-  qscloud create-sheet-icons \
+  browser install --browser chrome --browser-version 151.0.7922.77
+```
+
+**2. Mount that folder on every later run, and empty `PUPPETEER_EXECUTABLE_PATH`** so the embedded browser stops winning.
+
+**3. Ask for the same build you installed.** Butler Sheet Icons looks for the exact build id that `--browser-version` resolves to, so the two have to agree:
+
+```bash
+docker run --rm \
+  -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+  -v "$HOME/bsi/img:/nodeapp/img" \
+  -e PUPPETEER_EXECUTABLE_PATH="" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  qscloud create-sheet-thumbnails \
+  --browser-version 151.0.7922.77 \
   --tenanturl mytenant.eu.qlikcloud.com \
-  --apikey $BSI_API_KEY \
+  --apikey "$BSI_API_KEY" \
   --logonuserid user@company.com \
-  --logonpwd mypassword \
+  --logonpwd "$BSI_PASSWORD" \
   --appid 12345678-1234-1234-1234-123456789012 \
-  --browser chrome \
-  --browser-version 121.0.6167.85 \
-  --headless true
+  --imagedir ./img
 ```
 
-```powershell [Windows PowerShell]
-# List browsers in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser list-installed
+A successful run says which one it picked:
 
-# Install a specific Chrome build in container
-docker run -it --rm ptarmiganlabs/butler-sheet-icons:latest browser install --browser chrome --browser-version 121.0.6167.85
-
-# Use that build for sheet icons
-docker run -it --rm `
-  -v ${PWD}/images:/nodeapp/img `
-  ptarmiganlabs/butler-sheet-icons:latest `
-  qscloud create-sheet-icons `
-  --tenanturl mytenant.eu.qlikcloud.com `
-  --apikey $env:BSI_API_KEY `
-  --logonuserid user@company.com `
-  --logonpwd mypassword `
-  --appid 12345678-1234-1234-1234-123456789012 `
-  --browser chrome `
-  --browser-version 121.0.6167.85 `
-  --headless true
+```
+info: Using cached browser: chrome 151.0.7922.77
+info: Browser ready from cache: chrome 151.0.7922.77
 ```
 
+::: warning Do not mount a browser folder built on Windows or macOS
+The folder has to contain a **Linux** browser. A cache filled by running Butler Sheet Icons on a Windows desktop contains Windows builds, and mounting it into the container does not fail cleanly — Butler Sheet Icons accepts the entry and then tries to start a `.exe` inside a Linux container.
+
+Filling the folder with the command in step 1 avoids this, because the download then happens inside the container. See [Docker image with external browser](/guide/concepts/browser-detection-and-environment-variables#docker-image-with-external-browser).
+:::
+
+::: warning Clearing `PUPPETEER_EXECUTABLE_PATH` without providing a browser breaks the run
+With the variable emptied and no usable cache mounted, the container has no browser and tries to download one. On a host with no internet access that ends the run:
+
+```
+info: No local browser found. Downloading and installing browser...
+error: Error installing browser: Browser "chrome" version "recommended" cannot be downloaded. Please use the "list-available" command to check available versions
+```
+
+Mount the folder, or leave the embedded browser alone.
 :::
 
 ## Diagnostics and troubleshooting

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -326,37 +326,110 @@ docker run --rm `
 
 ### Docker image with external browser
 
-Sometimes you may want to use a different or newer browser than the one embedded in the image.
+Sometimes you want the container to use a specific browser build rather than the Chromium that comes with the image — usually because your organization approves browser versions centrally.
 
-You can do this in two main ways:
+This takes three things, and leaving out any one of them breaks the run:
 
-1. Mount a Puppeteer cache directory from the host
-2. Point `PUPPETEER_EXECUTABLE_PATH` to a browser in a mounted directory
+1. A folder on the host holding a **Linux** browser build, mounted at `/home/nodejs/.cache/puppeteer` in the container.
+2. `PUPPETEER_EXECUTABLE_PATH` set to an empty string, so the embedded browser stops taking priority.
+3. `--browser-version` set to **the same build** that is in the folder.
 
-**Windows / PowerShell example (mount cached browser from host):**
+#### Fill the folder from inside a container
 
-```powershell
-# Host cache directory (created earlier with browser install commands)
-$cachePath = "$env:USERPROFILE\.cache\puppeteer"
+The browser has to be a Linux build, because the container is Linux. The reliable way to get one is to let the container download it — then it cannot be the wrong kind. This step needs internet access, and is done once:
+
+::: code-group
+
+```bash [macOS/Linux]
+mkdir -p "$HOME/bsi/browser-cache"
+
+docker run --rm \
+  -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  browser install --browser chrome --browser-version 151.0.7922.77
+```
+
+```powershell [Windows PowerShell]
+$cachePath = 'C:\bsi-browser-cache'
+New-Item -ItemType Directory -Path $cachePath -Force | Out-Null
+
+docker run --rm `
+  -v "${cachePath}:/home/nodejs/.cache/puppeteer" `
+  ptarmiganlabs/butler-sheet-icons:latest `
+  browser install --browser chrome --browser-version 151.0.7922.77
+```
+
+:::
+
+::: danger Do not mount your own desktop's browser folder
+On Windows, `%USERPROFILE%\.cache\puppeteer` holds browsers downloaded **for Windows**. Mounting it into the container does not produce a clear error — Butler Sheet Icons accepts the entry and then tries to run a `.exe` inside a Linux container. The same applies to a macOS cache.
+
+Use the command above instead, which downloads a Linux build into a folder you nominate.
+:::
+
+#### Use it
+
+::: code-group
+
+```bash [macOS/Linux]
+docker run --rm \
+  -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+  -v "$HOME/bsi/img:/nodeapp/img" \
+  -e PUPPETEER_EXECUTABLE_PATH="" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  qscloud create-sheet-thumbnails \
+  --browser-version 151.0.7922.77 \
+  --tenanturl "$BSI_CLOUD_TENANT_URL" \
+  --apikey "$BSI_CLOUD_API_KEY" \
+  --appid "$BSI_CLOUD_APP_ID" \
+  --imagedir ./img
+```
+
+```powershell [Windows PowerShell]
+$cachePath = 'C:\bsi-browser-cache'
 $imgPath = 'C:\bsi-img'
 New-Item -ItemType Directory -Path $imgPath -Force | Out-Null
 
-# Use cached browser, ignore embedded one
-$env:PUPPETEER_EXECUTABLE_PATH = ''
-
 docker run --rm `
-  -v "$cachePath:/home/nodejs/.cache/puppeteer" `
-  -v "$imgPath:/nodeapp/img" `
+  -v "${cachePath}:/home/nodejs/.cache/puppeteer" `
+  -v "${imgPath}:/nodeapp/img" `
   -e PUPPETEER_EXECUTABLE_PATH="" `
   ptarmiganlabs/butler-sheet-icons:latest `
   qscloud create-sheet-thumbnails `
+  --browser-version 151.0.7922.77 `
   --tenanturl $env:BSI_CLOUD_TENANT_URL `
   --apikey $env:BSI_CLOUD_API_KEY `
   --appid $env:BSI_CLOUD_APP_ID `
   --imagedir ./img
 ```
 
-In this setup BSI ignores the embedded browser and uses the cached one from the host.
+:::
+
+A run that picked up the mounted browser says so:
+
+```
+info: Found 1 cached browser(s)
+info: Using cached browser: chrome 151.0.7922.77
+info: Browser ready from cache: chrome 151.0.7922.77
+```
+
+::: warning "Found 1 cached browser(s)" followed by "No local browser found"
+These two lines together mean the folder was read, but the browser in it is not the build that was asked for — so it was skipped. Both lines are accurate; it is the pair that is confusing.
+
+The fix is to make `--browser-version` name the build that is actually in the folder. Run `browser list-installed` with the folder mounted to see what that is:
+
+```bash
+docker run --rm \
+  -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  browser list-installed
+```
+
+:::
+
+#### The simpler alternative
+
+If a specific build is not actually a requirement, do nothing: the browser inside the image is already there, already Linux, and needs no internet access. See [Air-gapped environments](/guide/advanced/docker#air-gapped-environments).
 
 ## Thumbnail generation examples
 


### PR DESCRIPTION
Two sections told administrators to do things that cannot work. Drafts 2 and 4 are on one branch because they are the same subject and cross-link to each other.

## `/examples/browser-management` — "Docker usage"

Opened with **"Browsers in Docker are downloaded inside the container"**, which is false. The image ships Chromium and points `PUPPETEER_EXECUTABLE_PATH` at it. All three commands in the section were no-ops:

- `browser list-installed` reports `info: No browsers installed` — correct, since the embedded browser is a system package, not a cache entry.
- `browser install` in a `--rm` container throws the download away, and needs internet access.
- The run that claimed to use that build gets the embedded browser instead, and says so: `warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85"...`

## `/guide/concepts/browser-detection-and-environment-variables` — "Docker image with external browser"

Told Windows users to mount `%USERPROFILE%\.cache\puppeteer` into a Linux container. That folder holds **Windows** builds, and it does not fail cleanly — the entry is accepted and a `.exe` is handed back as the browser to run.

The example also passed no `--browser-version`, so nothing in the folder could have matched: the build id is resolved first and only that exact build is accepted.

## What both now say

Three things have to line up: a **Linux** browser in the mounted folder, an emptied `PUPPETEER_EXECUTABLE_PATH`, and a `--browser-version` naming the build that is in the folder. Filling the folder by running `browser install` *inside* the container makes the platform right by construction.

Also documents the `Found 1 cached browser(s)` / `No local browser found` pair, which is what a build id mismatch looks like in the log.

## Verification

Each check ran `resolveBrowserExecutablePath()` inside `ptarmiganlabs/butler-sheet-icons@sha256:20f3621e937f0b9763dac6a69a53a8979a04debca2ac2666b53785a89cd1f617` under `--network none`, with a prepared folder mounted at `/home/nodejs/.cache/puppeteer`:

| Folder contained | Result |
| --- | --- |
| `chrome/linux_arm-151.0.7922.77`, asked for that build | `Using cached browser: chrome 151.0.7922.77`, `source: "cache"` |
| `chrome/win64-151.0.7922.77`, asked for that build | Returned `…/chrome-win64/chrome.exe` as the browser to run |
| `chrome/linux_arm-151.0.7922.77`, asked for `recommended` | `Found 1 cached browser(s)` then `No local browser found`, then the download failure |
| Nothing, `PUPPETEER_EXECUTABLE_PATH=""` | `Error installing browser: … cannot be downloaded` |

`os.homedir()` in the container is `/home/nodejs`, confirming the mount point the page already used. `browser install` writes to the same folder (`src/lib/browser/browser-install.js`).

**Not executed:** the `browser install` command in the new text needs internet access to Google's download service, which was unavailable while writing. Its mechanism was verified from the code and by mounting a hand-prepared folder. Worth running once before this reaches production.

`npm run docs:build` passes; all three `#anchor` fragments checked against the generated HTML.

## Follow-up, deliberately not done here

`121.0.6167.85` — a Chrome 121 build from early 2024 — still appears 12 times elsewhere on the browser management page. Normalising those is cosmetic and would bury the corrections above in an unrelated diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)