### PR TITLE
Document interactive mode, the truthful browser uninstall, and the log colour change

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -89,6 +89,7 @@ export default withMermaid({
             { text: "Introduction", link: "/guide/introduction" },
             { text: "Quick Start", link: "/guide/quick-start" },
             { text: "Installation", link: "/guide/installation" },
+            { text: "Interactive Mode", link: "/guide/interactive-mode" },
           ],
         },
         {

--- a/docs/guide/concepts/environment-variables.md
+++ b/docs/guide/concepts/environment-variables.md
@@ -123,6 +123,66 @@ butler-sheet-icons qscloud create-sheet-thumbnails
 - Command-line parameters override environment variables if both are provided.
 - On shared systems, avoid system-wide secrets in env vars; consider a proper secrets manager in production.
 
+## Output and interaction
+
+These do not configure a command — they control how Butler Sheet Icons presents itself.
+
+| Variable | Effect |
+|---|---|
+| `NO_COLOR` (any value) | Never colour the log output, even in a terminal |
+| `FORCE_COLOR=1` | Always colour it, even when redirecting to a file |
+| `FORCE_COLOR=0` | Never colour it — the same as `NO_COLOR` |
+| `BSI_NO_INTERACTIVE=1` | Refuse to prompt, even in a terminal. See [Interactive Mode](/guide/interactive-mode) |
+| `BSI_ASCII_ONLY=1` | Use plain ASCII instead of Unicode symbols in interactive mode |
+
+### Colour codes in captured logs
+
+::: warning Requires BSI 4.1.0 or later
+In earlier versions, colour instructions were written whether or not the output was going to a screen.
+:::
+
+Butler Sheet Icons colours its log output so that `info`, `warn` and `error` lines are easy to tell apart.
+Until 4.1.0 it did that **always** — so if you redirected output to a file, piped it into another tool, or
+let a scheduler capture it, the colour instructions were captured too:
+
+```
+2026-06-24T10:30:45.123Z ←[32minfo←[39m: App version: 4.0.0
+```
+
+instead of:
+
+```
+2026-06-24T10:30:45.123Z info: App version: 4.0.0
+```
+
+From 4.1.0 the check is automatic: colour goes to a terminal, and nothing else. Interactive sessions are
+unchanged; redirected output, pipes, `docker logs` and scheduler transcripts are now clean.
+
+This is not only cosmetic. Colour codes in a captured log break things that read it afterwards: a search
+for `info:` does not match `←[32minfo←[39m:`, and log shippers that parse a level field — Splunk, Elastic,
+Grafana Loki — see unexpected characters in it.
+
+If you were stripping these characters yourself with a `sed` filter, a PowerShell replace, or a
+log-shipper rule, that workaround is no longer needed. Leaving it in place does no harm.
+
+Use `FORCE_COLOR=1` if you deliberately want a coloured transcript — for example when capturing output
+with a tool that renders colour back to you later.
+
+::: code-group
+
+```powershell [PowerShell]
+$env:FORCE_COLOR = "1"
+butler-sheet-icons.exe browser list-installed > coloured.log
+```
+
+```bash [Bash]
+FORCE_COLOR=1 butler-sheet-icons browser list-installed > coloured.log
+```
+
+:::
+
+A terminal reporting itself as `TERM=dumb` is also treated as unable to show colour.
+
 ## Related: Proxy environment variables
 
 When behind a proxy, set standard proxy variables (Linux/macOS example):

--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -1,0 +1,174 @@
+# Interactive Mode
+
+Butler Sheet Icons can ask you what it needs instead of expecting you to assemble a command line.
+
+```bash
+butler-sheet-icons interactive
+```
+
+You get a menu, a few questions, and — before anything happens — the exact command line your answers
+correspond to.
+
+::: warning Requires BSI 4.1.0 or later
+Interactive mode is not available in earlier versions.
+:::
+
+Nothing about the existing commands changes. Every option still works exactly as before, and automation
+is unaffected.
+
+This first release covers the two browser commands. The Qlik Sense thumbnail commands, which have the
+longest option lists and would benefit most, are planned for a later release.
+
+## Why use it?
+
+Three reasons, in rough order of how often they matter.
+
+**You do not have to know what is installed.** `browser uninstall` requires both `--browser` and
+`--browser-version`, with the version typed exactly right, and nothing tells you what is on the machine.
+Interactively, you pick from the browsers actually in the cache:
+
+```
+? Which browser build should be removed?
+❯ chrome  151.0.7922.47  (mac_arm)
+  chrome  150.0.7871.24  (mac_arm)
+```
+
+**Mistakes are caught as you make them.** Each answer is checked against the same rule the command line
+uses, with the same wording. Type a word where a number belongs and you are told immediately, rather than
+after you have typed out the rest of the command.
+
+**It teaches you the command line.** Before running anything, Butler Sheet Icons shows you what you just
+built:
+
+```
+── Review ──────────────────────────────────────
+
+  Equivalent command:
+  butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+
+? Ready?
+❯ Run it
+  Start over
+  Cancel
+```
+
+That line is the real thing. Copy it into a scheduled task, a script, or a support ticket and it produces
+exactly the same result. This is the intended path from *"I clicked through it once"* to *"it runs every
+night"*.
+
+Options you left at their default are left off the line, so what you see is the shortest command that
+does what you asked.
+
+## What can I do with it?
+
+| Wizard | What it replaces |
+|---|---|
+| **Install a browser into the cache** | [`browser install`](/reference/browser) — pick from published versions by typing to filter, or take the recommended build |
+| **Uninstall a browser from the cache** | [`browser uninstall`](/reference/browser) — pick from what is actually installed |
+
+Choose **Exit** to leave without doing anything. `Ctrl+C` at any point does the same — nothing is changed
+unless you choose **Run it**.
+
+There is no way to go back to a previous question. If you want to change an earlier answer, choose
+**Start over** at the review step.
+
+### Browsers built for another platform
+
+If your browser cache came from another machine — copied to prepare an offline server, shared over a
+network drive, or mounted into a container — it can hold browsers built for a different operating system.
+Those are shown, and labelled:
+
+```
+  chrome  151.0.7922.47  (built for win64 - cannot run here)
+```
+
+They remain selectable on purpose. A browser you cannot run is still taking up disk space, and removing
+it is a perfectly reasonable thing to want.
+
+## What happens when there is no terminal?
+
+Interactive mode needs a terminal, and it checks before asking anything. If there is not one, it says so
+and exits immediately with a non-zero exit code:
+
+```
+Interactive mode needs a terminal. Standard input is not a terminal - this happens with piped input,
+cron, "docker run" without -it, and most CI runners. Re-run with the options on the command line, or
+start the container with "docker run -it".
+```
+
+**It never waits for input that cannot arrive.** This matters: a command that blocks forever inside a
+scheduled task is a far worse outcome than one that fails immediately with an explanation.
+
+The same applies to terminals that cannot support prompting at all. PowerShell ISE, for example, has no
+console behind it and cannot report keystrokes; Butler Sheet Icons detects this and refuses with guidance
+rather than appearing to hang.
+
+To run interactively in Docker, attach a terminal:
+
+```bash
+docker run -it ptarmiganlabs/butler-sheet-icons:latest interactive
+```
+
+## Can I turn it off?
+
+Yes. Two environment variables control it.
+
+| Variable | Effect |
+|---|---|
+| `BSI_NO_INTERACTIVE=1` | Refuse to prompt, even in a terminal |
+| `BSI_ASCII_ONLY=1` | Use plain ASCII characters instead of Unicode symbols |
+
+`BSI_NO_INTERACTIVE=1` is worth setting in an environment where prompting should never happen regardless
+of how the command is launched — a shared build agent, for instance.
+
+::: tip Not disabled by CI
+Interactive mode is deliberately **not** disabled just because a `CI` variable is present. Plenty of
+people have that set in an ordinary shell where prompting is perfectly fine.
+:::
+
+`BSI_ASCII_ONLY=1` is for consoles that cannot render characters like `❯` and `─` and show them as
+meaningless symbols instead. Butler Sheet Icons detects most such consoles automatically, but if yours
+slips through, this forces the plain-text set:
+
+```
+  cursor        >
+  done          [ok]
+  failed        [!!]
+```
+
+See [Environment Variables](/guide/concepts/environment-variables) for the full list of variables Butler
+Sheet Icons understands.
+
+## The wizard looks wrong on my server
+
+There is a built-in diagnostic for exactly this:
+
+```bash
+butler-sheet-icons interactive --self-test
+```
+
+It reports what your terminal supports — whether it is a real terminal, whether colour is available, which
+character set is in use, the console code page on Windows — then draws every symbol, border and colour it
+would use, and finally shows one of each prompt type so you can see how they behave.
+
+It changes nothing: no connection to Qlik Sense, no downloads, nothing written to disk. It is safe to run
+anywhere, and pasting its output into a support issue is the fastest way to get a rendering problem
+diagnosed.
+
+If the output is being captured to a file rather than shown on screen, the prompt section is skipped and
+the report still completes.
+
+## Does this change how the commands work?
+
+No. Interactive mode is a front end that assembles options and then calls exactly the same code the
+command line does. The options it produces are identical to the ones you would get by typing the flags
+yourself — that equivalence is verified automatically for every command and every option.
+
+The plain command line remains the supported way to run Butler Sheet Icons unattended, and nothing about
+it has changed.
+
+## Related
+
+- [Browser Commands Reference](/reference/browser) — the full option list for the commands the wizards drive
+- [Environment Variables](/guide/concepts/environment-variables) — including the colour and interactive controls
+- [Troubleshooting](/guide/troubleshooting)

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -166,6 +166,10 @@ If you try to install an older Chrome version that's no longer available, you'll
 
 Removes a specific browser version from the BSI cache. This doesn't affect other browsers on your system, only those in the BSI cache.
 
+::: tip Pick from a list instead of typing a version
+`butler-sheet-icons interactive` offers the browsers actually in the cache, so you don't have to look up the exact build id first. See [Interactive Mode](/guide/interactive-mode).
+:::
+
 **Usage:**
 
 ```bash
@@ -204,6 +208,38 @@ PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser list-installed
 2024-02-16T14:26:44.597Z info: Installed browsers:
 2024-02-16T14:26:44.613Z info:     firefox, build id=124.0a1, platform=win64, path=C:\Users\goran\.cache\puppeteer\firefox\win64-124.0a1
 ```
+
+#### Browsers built for another platform
+
+::: warning Requires BSI 4.1.0 or later
+In earlier versions this command could report that it had removed a browser while the browser was still on disk. It printed a success message, exited with code 0, and left the files in place.
+:::
+
+The BSI cache labels each browser with the platform it was built for — `win64`, `mac_arm`, `linux`, and so on. A cache can hold builds for another platform in several ordinary ways:
+
+- The cache directory was copied from one machine to another, for example when preparing an offline server.
+- The cache is on a shared or network drive used by more than one machine.
+- The cache is mounted into a Docker container from a host running a different operating system.
+
+Such builds **can** be removed — a browser you cannot run still takes up disk space. From 4.1.0 the removal actually happens, and the result is verified before success is reported.
+
+When removal fails, the command says so and exits with a non-zero code, so a scheduled job can detect it:
+
+```
+error: Browser "chrome", version "151.0.7922.47" (built for win64) could not be removed. It is still in the cache at C:\Users\goran\.cache\puppeteer\chrome\win64-151.0.7922.47.
+```
+
+When the same version is cached for more than one platform, the build that can run on the current machine is removed first, and the ambiguity is reported:
+
+```
+warn: Build 151.0.7922.47 is cached for 2 platforms (win64, mac_arm). Removing the "win64" build; re-run to remove the next one.
+```
+
+Run the command again to remove the second one.
+
+::: tip Worth checking once
+If you have previously cleaned up browsers on a machine, run `browser list-installed` to check whether builds you believed were deleted are still there. If they are, `browser uninstall` will now remove them properly.
+:::
 
 ### uninstall-all
 


### PR DESCRIPTION
Publishes three staged drafts from [butler-sheet-icons#972](https://github.com/ptarmiganlabs/butler-sheet-icons/pull/972).

| Page | Created / edited | What changed | From which draft |
|---|---|---|---|
| `/guide/interactive-mode` | **Created** | The whole feature: menu, the two browser wizards, the echoed command line, non-TTY behaviour, `--self-test` | `interactive-mode.md` |
| `/reference/browser` | Edited | New section on builds downloaded for another platform, where `uninstall` used to report success while deleting nothing. Plus a pointer to interactive mode from the uninstall intro | `browser-uninstall-reports-truthfully.md` |
| `/guide/concepts/environment-variables` | Edited | New "Output and interaction" section: `NO_COLOR`, `FORCE_COLOR`, `BSI_NO_INTERACTIVE`, `BSI_ASCII_ONLY`, and the change that stopped colour codes reaching redirected logs | `log-output-no-longer-contains-colour-codes.md` |

Sidebar entry added for the new page under Getting Started.

`npm run docs:build` passes, so no dead links.

Every quoted message, option name and environment variable was checked against the implementation rather than taken from the drafts.

**One thing to confirm before this reaches `main`:** the pages are gated on `Requires BSI 4.1.0 or later`. That follows from the feature commits against 4.0.0, but the release-please PR does not exist yet — worth re-checking once butler-sheet-icons#972 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)