### PR TITLE
Publish the four remaining 4.0.0 drafts into the pages that already own their topics

### DIFF
--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -186,6 +186,43 @@ Yes. Run Butler Sheet Icons with `--loglevel debug` (or set the `BSI_LOG_LEVEL` 
 **What if the crash happens before Butler Sheet Icons can even read the environment variables?**
 The redaction and timeout logic in the crash dump writer is designed to handle this. The first time an unhandled error fires, the safety net writes the dump using whatever environment is already set; if the dump directory cannot be created, the write is skipped silently and the process exits.
 
+
+## How many dumps a single run can write
+
+::: warning Requires BSI 4.0.0 or later
+Earlier versions could write one crash dump per unhandled error. A single run that produced a burst of them filled the dump directory with hundreds of near-identical files, and the run did not reliably end.
+:::
+
+A run now writes **one** crash dump for the first failure, and stops there. When a run does produce repeated failures, a limit caps how many files can ever be written:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BSI_CRASH_DUMP_MAX_PER_PROCESS` | `10` | Maximum crash dumps a single run may write. Set to `0` for no limit. |
+
+When the limit is reached, one line says so and no further files are written:
+
+```
+CRASH DUMP: Limit of 10 dumps per process reached, no further dumps will be written. Set BSI_CRASH_DUMP_MAX_PER_PROCESS to raise or remove the limit.
+```
+
+### Cleaning up dumps written by an older version
+
+If a machine has a directory full of near-identical dumps from before the upgrade, they are safe to delete once you have kept any you want to investigate.
+
+::: code-group
+
+```powershell [PowerShell]
+Get-ChildItem $env:TEMP\butler-sheet-icons-crash-* | Remove-Item
+```
+
+```bash [Bash]
+rm /tmp/butler-sheet-icons-crash-*
+```
+
+:::
+
+Adjust the path if `BSI_CRASH_DUMP_DIR` points somewhere else.
+
 ## Related
 
 - [Secret redaction in logs](/reference/log-redaction) — what is redacted from log output, and how that differs from the redaction applied to crash dumps.

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -146,6 +146,27 @@ butler-sheet-icons qscloud create-sheet-thumbnails `
 - BSI captures screenshots and stores thumbnails per app and platform (Cloud/QSEoW).
 - Blurred images are saved with a `-blurred` suffix next to the regular thumbnails.
 
+
+## Blurring by tag
+
+::: warning Requires BSI 4.0.0 or later
+`--blur-sheet-tag` was accepted on the command line long before it did anything. On client-managed Qlik Sense nothing ever asked Qlik Sense which sheets carried the tag, so no sheet was ever blurred because of it.
+:::
+
+On client-managed Qlik Sense (QSEoW), `--blur-sheet-tag` now works: sheets carrying the named tag get a blurred thumbnail, exactly as with `--blur-sheet-number`, `--blur-sheet-title` or `--blur-sheet-status`.
+
+If you are upgrading from 4.0.0, note that each run used to log this line:
+
+```
+--blur-sheet-tag is not yet implemented for QSEoW and will be ignored.
+```
+
+**That warning is gone.** If you built a monitoring rule or a log filter matching it, the rule will stop firing — remove it.
+
+::: tip Tagging is a Qlik Sense feature
+Tags are applied to sheets in Qlik Sense itself, not in Butler Sheet Icons. Any sheet carrying the tag you name is blurred, which makes this the easiest filter to maintain when the set of sensitive sheets changes often — no command line has to be edited.
+:::
+
 ## Related
 
 - Sheet exclusion: See [Sheet Exclusion](/guide/concepts/sheet-exclusion) for analogous exclude filters and status nuances.

--- a/docs/guide/concepts/sheet-parts.md
+++ b/docs/guide/concepts/sheet-parts.md
@@ -93,3 +93,24 @@ butler-sheet-icons qseow create-sheet-thumbnails `
 - QS Cloud commands: [/reference/qscloud](/reference/qscloud)
 - Browser management (for debugging and sizing): [/guide/concepts/browser-management](/guide/concepts/browser-management)
 - How it works (architecture and flow): [/guide/concepts/how-it-works](/guide/concepts/how-it-works)
+
+## Valid values are checked before the run starts
+
+::: warning Requires BSI 4.0.0 or later
+In earlier versions an invalid value was accepted and the run began. The error appeared much later — after certificates were checked, connections opened and the browser started.
+:::
+
+`--includesheetpart` is now validated by the command line itself, so a wrong value costs a second rather than a failed run:
+
+```
+error: option '--includesheetpart <value>' argument '9' is invalid. Allowed choices are 1, 2, 3, 4.
+```
+
+The valid values also appear in `--help`, so they can be found without leaving the terminal. They differ between the two back ends, which is deliberate rather than an oversight:
+
+| Command | Valid values |
+|---|---|
+| `qseow create-sheet-thumbnails` | `1`, `2`, `3`, `4` |
+| `qscloud create-sheet-thumbnails` | `1`, `2`, `4` — `3` (selection bar) has no Qlik Sense Cloud equivalent |
+
+The same check applies to values supplied through `BSI_QSEOW_CST_INCLUDE_SHEET_PART` and `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART`, with a message naming the variable the value came from.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -31,6 +31,36 @@ butler-sheet-icons qscloud create-sheet-icons --headless false
 butler-sheet-icons browser list-installed
 ```
 
+
+## Fixed in 4.0.0: options and messages that told you the wrong thing
+
+::: warning Requires BSI 4.0.0 or later
+If you are running an earlier version, the behaviour described below still applies to you and the workarounds may still be needed.
+:::
+
+Five fixes in 4.0.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
+
+### Two options that never took effect
+
+| Option | What happened before |
+|---|---|
+| `--skip-login` (QS Cloud) | Silently ignored. Login was always attempted, and the log line announcing the skip could never appear. |
+| `--port` (QSEoW) | Not available, so a Qlik Sense server on a non-default port could not be reached without a proxy. |
+
+Both now behave as documented. If you set `--skip-login` and worked around it being ignored, that workaround is no longer needed.
+
+### Three errors that named the wrong cause
+
+These did not change what fails — they changed what you are told, which is the difference between a five-minute fix and an afternoon.
+
+| Symptom | Before | Now |
+|---|---|---|
+| A certificate file exists but cannot be read — wrong permissions, or a directory where a file was expected | Reported as a **missing** certificate, sending you to look for a file that was there all along | Reports that the file could not be read, and why |
+| The Qlik Sense server answers, but with something unexpected — a proxy login page, an error body | Reported as a **missing content library**, sending you to check a content library that was fine | Reports that the server's answer could not be understood |
+| A per-app lookup fails for one app | Surfaced as an internal error, with no indication which app | Names the app and continues with the rest |
+
+If you have monitoring rules or log filters matching the old wording, they will stop firing. That is the point — but they need removing.
+
 ## Run Failures and Exit Codes
 
 ::: warning Requires BSI 4.0.0 or later


### PR DESCRIPTION
Processes the pending drafts left in `docs/to-doc-site/` after [butler-sheet-icons#972](https://github.com/ptarmiganlabs/butler-sheet-icons/pull/972).

| Page | Created / edited | What changed | From which draft |
|---|---|---|---|
| `/guide/concepts/sheet-parts` | Edited | `--includesheetpart` is validated at the command line; per-back-end value sets stated | `includesheetpart-validation-improved.md` |
| `/guide/concepts/sheet-blurring` | Edited | `--blur-sheet-tag` works on QSEoW; the old "not yet implemented" warning is gone | `blur-sheet-tag-now-works.md` |
| `/guide/advanced/crash-dumps` | Edited | One dump per run, `BSI_CRASH_DUMP_MAX_PER_PROCESS`, cleanup for older versions | `one-crash-dump-per-run.md` |
| `/guide/troubleshooting` | Edited | The five option and message fixes, as a symptom table | `options-and-messages-that-told-you-the-wrong-thing.md` |

All four describe **4.0.0** behaviour — already released — so they are gated on 4.0.0, not 4.1.0.

**Not published: `windows-binary-temporarily-unsigned.md`.** It is stale. `scripts/release-win.ps1` has two live `signtool sign` calls and none commented out, so the Windows release binary is signed and publishing the draft would tell users otherwise. The live site makes no such claim, so there is nothing to correct — the draft is simply retired.

`npm run docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)