### PR TITLE
docs: correct five version gates to 4.1.0

### DIFF
--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -189,7 +189,7 @@ The redaction and timeout logic in the crash dump writer is designed to handle t
 
 ## How many dumps a single run can write
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 Earlier versions could write one crash dump per unhandled error. A single run that produced a burst of them filled the dump directory with hundreds of near-identical files, and the run did not reliably end.
 :::
 

--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -31,8 +31,8 @@ When you run Butler Sheet Icons **outside** Docker — as a pre-built binary —
 
 ### Where to find the licence information
 
-::: warning Requires BSI 4.0.1 or later
-The `/nodeapp/licenses/` directory described below does not exist in earlier images, and earlier images also stripped most licence files out of `node_modules` to save space. On a 4.0.0 image the `find` command below returns 23 results; from 4.0.1 it returns 162.
+::: warning Requires BSI 4.1.0 or later
+The `/nodeapp/licenses/` directory described below does not exist in earlier images, and earlier images also stripped most licence files out of `node_modules` to save space. On a 4.0.0 image the `find` command below returns 23 results; from 4.1.0 it returns 162.
 
 The Chromium credits page and the Alpine package database are present in older images too.
 :::

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -149,7 +149,7 @@ butler-sheet-icons qscloud create-sheet-thumbnails `
 
 ## Blurring by tag
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 `--blur-sheet-tag` was accepted on the command line long before it did anything. On client-managed Qlik Sense nothing ever asked Qlik Sense which sheets carried the tag, so no sheet was ever blurred because of it.
 :::
 

--- a/docs/guide/concepts/sheet-parts.md
+++ b/docs/guide/concepts/sheet-parts.md
@@ -96,7 +96,7 @@ butler-sheet-icons qseow create-sheet-thumbnails `
 
 ## Valid values are checked before the run starts
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 In earlier versions an invalid value was accepted and the run began. The error appeared much later — after certificates were checked, connections opened and the browser started.
 :::
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -32,13 +32,13 @@ butler-sheet-icons browser list-installed
 ```
 
 
-## Fixed in 4.0.0: options and messages that told you the wrong thing
+## Fixed in 4.1.0: options and messages that told you the wrong thing
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 If you are running an earlier version, the behaviour described below still applies to you and the workarounds may still be needed.
 :::
 
-Five fixes in 4.0.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
+Five fixes in 4.1.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
 
 ### Two options that never took effect
 


### PR DESCRIPTION
Found while preparing the `next` → `main` release merge for BSI 4.1.0. Five sections carry a version gate that does not match where the behaviour actually shipped — one of them names **4.0.1**, a version that was never released.

Every claim verified with `git tag --contains` against `ptarmiganlabs/butler-sheet-icons`, not just release notes.

| File | Section | Was | Now | Evidence |
|---|---|---|---|---|
| `guide/advanced/docker.md` | Licence notices, `/nodeapp/licenses/` | **4.0.1** (never released) | 4.1.0 | `5caaaaa` |
| `guide/advanced/crash-dumps.md` | `BSI_CRASH_DUMP_MAX_PER_PROCESS` cap | 4.0.0 | 4.1.0 | `15f7fc6`, `a424a9f` |
| `guide/concepts/sheet-blurring.md` | Blurring by tag on QSEoW | 4.0.0 | 4.1.0 | `c332e13` |
| `guide/concepts/sheet-parts.md` | `--includesheetpart` checked at parse time | 4.0.0 | 4.1.0 | `e27b326` |
| `guide/troubleshooting.md` | "Fixed in 4.0.0: options and messages…" | 4.0.0 | 4.1.0 | `b461562`, `42f1895`, `bf554ab`, `40064ba`, `94e0e9d` |

4.0.0 did ship *adjacent* work in three of these areas, which is how the drafts drifted: it introduced crash dumps (but not the cap), stopped `--blur-sheet-tag` crashing QSEoW (but never looked the tags up), and normalised `--includesheetpart` (but validated it late). The 4.1.0 commits are the ones the prose actually describes.

This is the release-please recompute trap documented in `README_DEPLOY.md` — drafts written while the pending release was going to be 4.0.1, which shipped as 4.1.0.

Two sections already contradicted their own gate: `sheet-blurring.md` says "if you are upgrading from 4.0.0" under a "requires 4.0.0" warning, and `troubleshooting.md` said "Five fixes in 4.0.0" for five 4.1.0 fixes.

### Scope

Version numbers only — no wording changes. The `troubleshooting.md` heading changes too, so its anchor becomes `#fixed-in-4-1-0-…`; nothing in the site links to the old anchor (checked).

Gates deliberately left alone because they are correct: exit codes and Docker bind-mount ownership (4.0.0, `fef9183` / `4f18bda`), and interactive mode, browser uninstall and log colour (4.1.0, `778d0fb` / `25915a3` / `7d5d59c`).

`npm run docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)