### PR TITLE
Publish docs for Butler Sheet Icons 4.1.0

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -89,6 +89,7 @@ export default withMermaid({
             { text: "Introduction", link: "/guide/introduction" },
             { text: "Quick Start", link: "/guide/quick-start" },
             { text: "Installation", link: "/guide/installation" },
+            { text: "Interactive Mode", link: "/guide/interactive-mode" },
           ],
         },
         {

--- a/docs/examples/docker.md
+++ b/docs/examples/docker.md
@@ -11,6 +11,8 @@ The official image includes an embedded Chromium browser, so it needs no interne
 - Platforms: AMD64, ARM64
 - Registry: Docker Hub
 
+For what the image contains besides Butler Sheet Icons, and where to find the licences of that software, see [What is inside the image](/guide/advanced/docker#what-is-inside-the-image).
+
 ## Basic Usage
 
 ### Help and Version Information

--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -186,6 +186,43 @@ Yes. Run Butler Sheet Icons with `--loglevel debug` (or set the `BSI_LOG_LEVEL` 
 **What if the crash happens before Butler Sheet Icons can even read the environment variables?**
 The redaction and timeout logic in the crash dump writer is designed to handle this. The first time an unhandled error fires, the safety net writes the dump using whatever environment is already set; if the dump directory cannot be created, the write is skipped silently and the process exits.
 
+
+## How many dumps a single run can write
+
+::: warning Requires BSI 4.0.0 or later
+Earlier versions could write one crash dump per unhandled error. A single run that produced a burst of them filled the dump directory with hundreds of near-identical files, and the run did not reliably end.
+:::
+
+A run now writes **one** crash dump for the first failure, and stops there. When a run does produce repeated failures, a limit caps how many files can ever be written:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BSI_CRASH_DUMP_MAX_PER_PROCESS` | `10` | Maximum crash dumps a single run may write. Set to `0` for no limit. |
+
+When the limit is reached, one line says so and no further files are written:
+
+```
+CRASH DUMP: Limit of 10 dumps per process reached, no further dumps will be written. Set BSI_CRASH_DUMP_MAX_PER_PROCESS to raise or remove the limit.
+```
+
+### Cleaning up dumps written by an older version
+
+If a machine has a directory full of near-identical dumps from before the upgrade, they are safe to delete once you have kept any you want to investigate.
+
+::: code-group
+
+```powershell [PowerShell]
+Get-ChildItem $env:TEMP\butler-sheet-icons-crash-* | Remove-Item
+```
+
+```bash [Bash]
+rm /tmp/butler-sheet-icons-crash-*
+```
+
+:::
+
+Adjust the path if `BSI_CRASH_DUMP_DIR` points somewhere else.
+
 ## Related
 
 - [Secret redaction in logs](/reference/log-redaction) — what is redacted from log output, and how that differs from the redaction applied to crash dumps.

--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -189,7 +189,7 @@ The redaction and timeout logic in the crash dump writer is designed to handle t
 
 ## How many dumps a single run can write
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 Earlier versions could write one crash dump per unhandled error. A single run that produced a burst of them filled the dump directory with hundreds of near-identical files, and the run did not reliably end.
 :::
 

--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -6,10 +6,103 @@ Butler Sheet Icons (BSI) is available as an official Docker image, making it eas
 - Runs headless; suitable for CI/CD and servers
 - Same features as pre-built binaries
 - Includes an embedded Chromium browser, so it needs no internet access at all — see [Air-gapped environments](#air-gapped-environments)
+- Contains third-party software with its own licences — see [What is inside the image](#what-is-inside-the-image)
 
 For details on how the container decides which browser to use, and how to override the embedded browser with a cached or system browser, see [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables).
 
 For concrete container commands (including QS Cloud, QSEoW, volume mounts, and docker-compose), see the dedicated [Docker Examples](/examples/docker) page.
+
+## What is inside the image
+
+The image is not only Butler Sheet Icons. It also contains a **Chromium browser**, because Butler Sheet Icons works by opening your Qlik Sense sheets in a browser and photographing them.
+
+Shipping the browser inside the image is deliberate. It is what allows the container to run in an environment with no internet access — nothing has to be downloaded the first time you use it.
+
+Chromium accounts for roughly 260 MB of the image. That is most of the reason the image is as large as it is.
+
+### Chromium is not Google Chrome
+
+This distinction matters if someone in your organization has to approve the image, and the two names are used interchangeably almost everywhere else:
+
+- **Google Chrome** and **Chrome for Testing** are Google-branded browsers, distributed under Google's own terms. The Butler Sheet Icons image contains neither of them.
+- **Chromium** is the open-source project that Chrome is built from. The image uses the Chromium package published by Alpine Linux, the same one Alpine ships to everybody else. It is recorded as BSD-3-Clause.
+
+When you run Butler Sheet Icons **outside** Docker — as a pre-built binary — it downloads Chrome for Testing onto your own machine the first time it needs a browser. That is a download you perform, not something Butler Sheet Icons redistributes, which is why the two situations are handled differently.
+
+### Where to find the licence information
+
+::: warning Requires BSI 4.0.1 or later
+The `/nodeapp/licenses/` directory described below does not exist in earlier images, and earlier images also stripped most licence files out of `node_modules` to save space. On a 4.0.0 image the `find` command below returns 23 results; from 4.0.1 it returns 162.
+
+The Chromium credits page and the Alpine package database are present in older images too.
+:::
+
+Every licence that applies to the image is inside the image, so a review can be completed without searching the internet for any of it.
+
+Start with the notice file, which lists each component and where its licence and source can be found:
+
+```bash
+docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+  -c 'cat /nodeapp/licenses/NOTICE.md'
+```
+
+The same directory holds the full licence text for Butler Sheet Icons itself and for Chromium:
+
+```bash
+docker run --rm --entrypoint sh ptarmiganlabs/butler-sheet-icons:latest \
+  -c 'ls /nodeapp/licenses/'
+```
+
+Three further sources, all inside the image:
+
+| What | How to see it |
+| --- | --- |
+| The 740 components bundled inside Chromium, with their licences | The `chrome://credits` page built into the browser — see below |
+| Licences of the Node.js packages Butler Sheet Icons uses | `find /nodeapp/node_modules -iname "LICENSE*"` |
+| Licences of every Alpine system package | `grep -E "^(P\|V\|L):" /lib/apk/db/installed` |
+
+To check which Chromium version a particular image contains:
+
+```bash
+docker run --rm --entrypoint /usr/bin/chromium-browser \
+  ptarmiganlabs/butler-sheet-icons:latest --version
+```
+
+### Reading the Chromium credits page
+
+Chromium bundles 740 further components, under licences including LGPL, MPL and MIT. They are listed on the browser's own `chrome://credits` page, which is built into the binary and needs no internet access.
+
+Getting at that page is more awkward than it looks, because a `chrome://` page cannot be reached from outside the container. This command drives the browser from inside it and saves the page as a file:
+
+::: details Command to save the credits page
+
+```bash
+docker run --rm --network none --entrypoint node \
+    ptarmiganlabs/butler-sheet-icons:latest --input-type=module -e "
+import puppeteer from 'puppeteer-core';
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium-browser',
+  headless: true,
+  args: ['--no-sandbox', '--disable-gpu'],
+});
+const page = await browser.newPage();
+await page.goto('chrome://credits', { waitUntil: 'domcontentloaded' });
+console.log(await page.content());
+await browser.close();
+" > chromium-credits.html
+```
+
+:::
+
+That writes about 18 MB of HTML containing all 740 components and their full licence texts. Open `chromium-credits.html` in any browser. It renders unstyled, because its stylesheets are `chrome://` addresses that only exist inside Chromium — which suits a review, since every licence text appears inline rather than hidden behind a control, and the file can be searched or printed as it is.
+
+The same command is in `NOTICE.md` inside the image, so it is available to a reviewer who has the image but not this page.
+
+::: tip Media codecs
+The Chromium build in the image can decode the H.264 and AAC media formats. These are covered by patent pools, which is a separate question from the licences above.
+
+Butler Sheet Icons never decodes audio or video — it takes still pictures of Qlik Sense sheets — so this capability is present only because it comes as part of the standard Chromium package. It is mentioned here because organizations with strict patent-licensing policies will want to know it is there.
+:::
 
 ## Writing thumbnails to a mounted folder on Linux
 
@@ -107,7 +200,7 @@ Qlik Sense Cloud lives on the public internet, so a genuinely air-gapped host ca
 
 ### Why the image is the easiest option
 
-The image already contains a Chromium browser — around 260 MB of the image, and the reason it is as large as it is.
+The image already contains a Chromium browser — around 260 MB of the image, and the reason it is as large as it is. See [What is inside the image](#what-is-inside-the-image) for the full inventory and its licensing.
 
 Two environment variables are set inside the image and point Butler Sheet Icons at that browser:
 

--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -31,8 +31,8 @@ When you run Butler Sheet Icons **outside** Docker — as a pre-built binary —
 
 ### Where to find the licence information
 
-::: warning Requires BSI 4.0.1 or later
-The `/nodeapp/licenses/` directory described below does not exist in earlier images, and earlier images also stripped most licence files out of `node_modules` to save space. On a 4.0.0 image the `find` command below returns 23 results; from 4.0.1 it returns 162.
+::: warning Requires BSI 4.1.0 or later
+The `/nodeapp/licenses/` directory described below does not exist in earlier images, and earlier images also stripped most licence files out of `node_modules` to save space. On a 4.0.0 image the `find` command below returns 23 results; from 4.1.0 it returns 162.
 
 The Chromium credits page and the Alpine package database are present in older images too.
 :::

--- a/docs/guide/concepts/environment-variables.md
+++ b/docs/guide/concepts/environment-variables.md
@@ -123,6 +123,66 @@ butler-sheet-icons qscloud create-sheet-thumbnails
 - Command-line parameters override environment variables if both are provided.
 - On shared systems, avoid system-wide secrets in env vars; consider a proper secrets manager in production.
 
+## Output and interaction
+
+These do not configure a command — they control how Butler Sheet Icons presents itself.
+
+| Variable | Effect |
+|---|---|
+| `NO_COLOR` (any value) | Never colour the log output, even in a terminal |
+| `FORCE_COLOR=1` | Always colour it, even when redirecting to a file |
+| `FORCE_COLOR=0` | Never colour it — the same as `NO_COLOR` |
+| `BSI_NO_INTERACTIVE=1` | Refuse to prompt, even in a terminal. See [Interactive Mode](/guide/interactive-mode) |
+| `BSI_ASCII_ONLY=1` | Use plain ASCII instead of Unicode symbols in interactive mode |
+
+### Colour codes in captured logs
+
+::: warning Requires BSI 4.1.0 or later
+In earlier versions, colour instructions were written whether or not the output was going to a screen.
+:::
+
+Butler Sheet Icons colours its log output so that `info`, `warn` and `error` lines are easy to tell apart.
+Until 4.1.0 it did that **always** — so if you redirected output to a file, piped it into another tool, or
+let a scheduler capture it, the colour instructions were captured too:
+
+```
+2026-06-24T10:30:45.123Z ←[32minfo←[39m: App version: 4.0.0
+```
+
+instead of:
+
+```
+2026-06-24T10:30:45.123Z info: App version: 4.0.0
+```
+
+From 4.1.0 the check is automatic: colour goes to a terminal, and nothing else. Interactive sessions are
+unchanged; redirected output, pipes, `docker logs` and scheduler transcripts are now clean.
+
+This is not only cosmetic. Colour codes in a captured log break things that read it afterwards: a search
+for `info:` does not match `←[32minfo←[39m:`, and log shippers that parse a level field — Splunk, Elastic,
+Grafana Loki — see unexpected characters in it.
+
+If you were stripping these characters yourself with a `sed` filter, a PowerShell replace, or a
+log-shipper rule, that workaround is no longer needed. Leaving it in place does no harm.
+
+Use `FORCE_COLOR=1` if you deliberately want a coloured transcript — for example when capturing output
+with a tool that renders colour back to you later.
+
+::: code-group
+
+```powershell [PowerShell]
+$env:FORCE_COLOR = "1"
+butler-sheet-icons.exe browser list-installed > coloured.log
+```
+
+```bash [Bash]
+FORCE_COLOR=1 butler-sheet-icons browser list-installed > coloured.log
+```
+
+:::
+
+A terminal reporting itself as `TERM=dumb` is also treated as unable to show colour.
+
 ## Related: Proxy environment variables
 
 When behind a proxy, set standard proxy variables (Linux/macOS example):

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -146,6 +146,27 @@ butler-sheet-icons qscloud create-sheet-thumbnails `
 - BSI captures screenshots and stores thumbnails per app and platform (Cloud/QSEoW).
 - Blurred images are saved with a `-blurred` suffix next to the regular thumbnails.
 
+
+## Blurring by tag
+
+::: warning Requires BSI 4.0.0 or later
+`--blur-sheet-tag` was accepted on the command line long before it did anything. On client-managed Qlik Sense nothing ever asked Qlik Sense which sheets carried the tag, so no sheet was ever blurred because of it.
+:::
+
+On client-managed Qlik Sense (QSEoW), `--blur-sheet-tag` now works: sheets carrying the named tag get a blurred thumbnail, exactly as with `--blur-sheet-number`, `--blur-sheet-title` or `--blur-sheet-status`.
+
+If you are upgrading from 4.0.0, note that each run used to log this line:
+
+```
+--blur-sheet-tag is not yet implemented for QSEoW and will be ignored.
+```
+
+**That warning is gone.** If you built a monitoring rule or a log filter matching it, the rule will stop firing — remove it.
+
+::: tip Tagging is a Qlik Sense feature
+Tags are applied to sheets in Qlik Sense itself, not in Butler Sheet Icons. Any sheet carrying the tag you name is blurred, which makes this the easiest filter to maintain when the set of sensitive sheets changes often — no command line has to be edited.
+:::
+
 ## Related
 
 - Sheet exclusion: See [Sheet Exclusion](/guide/concepts/sheet-exclusion) for analogous exclude filters and status nuances.

--- a/docs/guide/concepts/sheet-blurring.md
+++ b/docs/guide/concepts/sheet-blurring.md
@@ -149,7 +149,7 @@ butler-sheet-icons qscloud create-sheet-thumbnails `
 
 ## Blurring by tag
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 `--blur-sheet-tag` was accepted on the command line long before it did anything. On client-managed Qlik Sense nothing ever asked Qlik Sense which sheets carried the tag, so no sheet was ever blurred because of it.
 :::
 

--- a/docs/guide/concepts/sheet-parts.md
+++ b/docs/guide/concepts/sheet-parts.md
@@ -96,7 +96,7 @@ butler-sheet-icons qseow create-sheet-thumbnails `
 
 ## Valid values are checked before the run starts
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 In earlier versions an invalid value was accepted and the run began. The error appeared much later — after certificates were checked, connections opened and the browser started.
 :::
 

--- a/docs/guide/concepts/sheet-parts.md
+++ b/docs/guide/concepts/sheet-parts.md
@@ -93,3 +93,24 @@ butler-sheet-icons qseow create-sheet-thumbnails `
 - QS Cloud commands: [/reference/qscloud](/reference/qscloud)
 - Browser management (for debugging and sizing): [/guide/concepts/browser-management](/guide/concepts/browser-management)
 - How it works (architecture and flow): [/guide/concepts/how-it-works](/guide/concepts/how-it-works)
+
+## Valid values are checked before the run starts
+
+::: warning Requires BSI 4.0.0 or later
+In earlier versions an invalid value was accepted and the run began. The error appeared much later — after certificates were checked, connections opened and the browser started.
+:::
+
+`--includesheetpart` is now validated by the command line itself, so a wrong value costs a second rather than a failed run:
+
+```
+error: option '--includesheetpart <value>' argument '9' is invalid. Allowed choices are 1, 2, 3, 4.
+```
+
+The valid values also appear in `--help`, so they can be found without leaving the terminal. They differ between the two back ends, which is deliberate rather than an oversight:
+
+| Command | Valid values |
+|---|---|
+| `qseow create-sheet-thumbnails` | `1`, `2`, `3`, `4` |
+| `qscloud create-sheet-thumbnails` | `1`, `2`, `4` — `3` (selection bar) has no Qlik Sense Cloud equivalent |
+
+The same check applies to values supplied through `BSI_QSEOW_CST_INCLUDE_SHEET_PART` and `BSI_QSCLOUD_CST_INCLUDE_SHEET_PART`, with a message naming the variable the value came from.

--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -1,0 +1,174 @@
+# Interactive Mode
+
+Butler Sheet Icons can ask you what it needs instead of expecting you to assemble a command line.
+
+```bash
+butler-sheet-icons interactive
+```
+
+You get a menu, a few questions, and — before anything happens — the exact command line your answers
+correspond to.
+
+::: warning Requires BSI 4.1.0 or later
+Interactive mode is not available in earlier versions.
+:::
+
+Nothing about the existing commands changes. Every option still works exactly as before, and automation
+is unaffected.
+
+This first release covers the two browser commands. The Qlik Sense thumbnail commands, which have the
+longest option lists and would benefit most, are planned for a later release.
+
+## Why use it?
+
+Three reasons, in rough order of how often they matter.
+
+**You do not have to know what is installed.** `browser uninstall` requires both `--browser` and
+`--browser-version`, with the version typed exactly right, and nothing tells you what is on the machine.
+Interactively, you pick from the browsers actually in the cache:
+
+```
+? Which browser build should be removed?
+❯ chrome  151.0.7922.47  (mac_arm)
+  chrome  150.0.7871.24  (mac_arm)
+```
+
+**Mistakes are caught as you make them.** Each answer is checked against the same rule the command line
+uses, with the same wording. Type a word where a number belongs and you are told immediately, rather than
+after you have typed out the rest of the command.
+
+**It teaches you the command line.** Before running anything, Butler Sheet Icons shows you what you just
+built:
+
+```
+── Review ──────────────────────────────────────
+
+  Equivalent command:
+  butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+
+? Ready?
+❯ Run it
+  Start over
+  Cancel
+```
+
+That line is the real thing. Copy it into a scheduled task, a script, or a support ticket and it produces
+exactly the same result. This is the intended path from *"I clicked through it once"* to *"it runs every
+night"*.
+
+Options you left at their default are left off the line, so what you see is the shortest command that
+does what you asked.
+
+## What can I do with it?
+
+| Wizard | What it replaces |
+|---|---|
+| **Install a browser into the cache** | [`browser install`](/reference/browser) — pick from published versions by typing to filter, or take the recommended build |
+| **Uninstall a browser from the cache** | [`browser uninstall`](/reference/browser) — pick from what is actually installed |
+
+Choose **Exit** to leave without doing anything. `Ctrl+C` at any point does the same — nothing is changed
+unless you choose **Run it**.
+
+There is no way to go back to a previous question. If you want to change an earlier answer, choose
+**Start over** at the review step.
+
+### Browsers built for another platform
+
+If your browser cache came from another machine — copied to prepare an offline server, shared over a
+network drive, or mounted into a container — it can hold browsers built for a different operating system.
+Those are shown, and labelled:
+
+```
+  chrome  151.0.7922.47  (built for win64 - cannot run here)
+```
+
+They remain selectable on purpose. A browser you cannot run is still taking up disk space, and removing
+it is a perfectly reasonable thing to want.
+
+## What happens when there is no terminal?
+
+Interactive mode needs a terminal, and it checks before asking anything. If there is not one, it says so
+and exits immediately with a non-zero exit code:
+
+```
+Interactive mode needs a terminal. Standard input is not a terminal - this happens with piped input,
+cron, "docker run" without -it, and most CI runners. Re-run with the options on the command line, or
+start the container with "docker run -it".
+```
+
+**It never waits for input that cannot arrive.** This matters: a command that blocks forever inside a
+scheduled task is a far worse outcome than one that fails immediately with an explanation.
+
+The same applies to terminals that cannot support prompting at all. PowerShell ISE, for example, has no
+console behind it and cannot report keystrokes; Butler Sheet Icons detects this and refuses with guidance
+rather than appearing to hang.
+
+To run interactively in Docker, attach a terminal:
+
+```bash
+docker run -it ptarmiganlabs/butler-sheet-icons:latest interactive
+```
+
+## Can I turn it off?
+
+Yes. Two environment variables control it.
+
+| Variable | Effect |
+|---|---|
+| `BSI_NO_INTERACTIVE=1` | Refuse to prompt, even in a terminal |
+| `BSI_ASCII_ONLY=1` | Use plain ASCII characters instead of Unicode symbols |
+
+`BSI_NO_INTERACTIVE=1` is worth setting in an environment where prompting should never happen regardless
+of how the command is launched — a shared build agent, for instance.
+
+::: tip Not disabled by CI
+Interactive mode is deliberately **not** disabled just because a `CI` variable is present. Plenty of
+people have that set in an ordinary shell where prompting is perfectly fine.
+:::
+
+`BSI_ASCII_ONLY=1` is for consoles that cannot render characters like `❯` and `─` and show them as
+meaningless symbols instead. Butler Sheet Icons detects most such consoles automatically, but if yours
+slips through, this forces the plain-text set:
+
+```
+  cursor        >
+  done          [ok]
+  failed        [!!]
+```
+
+See [Environment Variables](/guide/concepts/environment-variables) for the full list of variables Butler
+Sheet Icons understands.
+
+## The wizard looks wrong on my server
+
+There is a built-in diagnostic for exactly this:
+
+```bash
+butler-sheet-icons interactive --self-test
+```
+
+It reports what your terminal supports — whether it is a real terminal, whether colour is available, which
+character set is in use, the console code page on Windows — then draws every symbol, border and colour it
+would use, and finally shows one of each prompt type so you can see how they behave.
+
+It changes nothing: no connection to Qlik Sense, no downloads, nothing written to disk. It is safe to run
+anywhere, and pasting its output into a support issue is the fastest way to get a rendering problem
+diagnosed.
+
+If the output is being captured to a file rather than shown on screen, the prompt section is skipped and
+the report still completes.
+
+## Does this change how the commands work?
+
+No. Interactive mode is a front end that assembles options and then calls exactly the same code the
+command line does. The options it produces are identical to the ones you would get by typing the flags
+yourself — that equivalence is verified automatically for every command and every option.
+
+The plain command line remains the supported way to run Butler Sheet Icons unattended, and nothing about
+it has changed.
+
+## Related
+
+- [Browser Commands Reference](/reference/browser) — the full option list for the commands the wizards drive
+- [Environment Variables](/guide/concepts/environment-variables) — including the colour and interactive controls
+- [Troubleshooting](/guide/troubleshooting)

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -31,6 +31,36 @@ butler-sheet-icons qscloud create-sheet-icons --headless false
 butler-sheet-icons browser list-installed
 ```
 
+
+## Fixed in 4.0.0: options and messages that told you the wrong thing
+
+::: warning Requires BSI 4.0.0 or later
+If you are running an earlier version, the behaviour described below still applies to you and the workarounds may still be needed.
+:::
+
+Five fixes in 4.0.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
+
+### Two options that never took effect
+
+| Option | What happened before |
+|---|---|
+| `--skip-login` (QS Cloud) | Silently ignored. Login was always attempted, and the log line announcing the skip could never appear. |
+| `--port` (QSEoW) | Not available, so a Qlik Sense server on a non-default port could not be reached without a proxy. |
+
+Both now behave as documented. If you set `--skip-login` and worked around it being ignored, that workaround is no longer needed.
+
+### Three errors that named the wrong cause
+
+These did not change what fails — they changed what you are told, which is the difference between a five-minute fix and an afternoon.
+
+| Symptom | Before | Now |
+|---|---|---|
+| A certificate file exists but cannot be read — wrong permissions, or a directory where a file was expected | Reported as a **missing** certificate, sending you to look for a file that was there all along | Reports that the file could not be read, and why |
+| The Qlik Sense server answers, but with something unexpected — a proxy login page, an error body | Reported as a **missing content library**, sending you to check a content library that was fine | Reports that the server's answer could not be understood |
+| A per-app lookup fails for one app | Surfaced as an internal error, with no indication which app | Names the app and continues with the rest |
+
+If you have monitoring rules or log filters matching the old wording, they will stop firing. That is the point — but they need removing.
+
 ## Run Failures and Exit Codes
 
 ::: warning Requires BSI 4.0.0 or later

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -32,13 +32,13 @@ butler-sheet-icons browser list-installed
 ```
 
 
-## Fixed in 4.0.0: options and messages that told you the wrong thing
+## Fixed in 4.1.0: options and messages that told you the wrong thing
 
-::: warning Requires BSI 4.0.0 or later
+::: warning Requires BSI 4.1.0 or later
 If you are running an earlier version, the behaviour described below still applies to you and the workarounds may still be needed.
 :::
 
-Five fixes in 4.0.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
+Five fixes in 4.1.0 share a theme: Butler Sheet Icons accepted something, or reported something, that did not match what it actually did. If you built a workaround around any of them, it can now be removed.
 
 ### Two options that never took effect
 

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -166,6 +166,10 @@ If you try to install an older Chrome version that's no longer available, you'll
 
 Removes a specific browser version from the BSI cache. This doesn't affect other browsers on your system, only those in the BSI cache.
 
+::: tip Pick from a list instead of typing a version
+`butler-sheet-icons interactive` offers the browsers actually in the cache, so you don't have to look up the exact build id first. See [Interactive Mode](/guide/interactive-mode).
+:::
+
 **Usage:**
 
 ```bash
@@ -204,6 +208,38 @@ PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser list-installed
 2024-02-16T14:26:44.597Z info: Installed browsers:
 2024-02-16T14:26:44.613Z info:     firefox, build id=124.0a1, platform=win64, path=C:\Users\goran\.cache\puppeteer\firefox\win64-124.0a1
 ```
+
+#### Browsers built for another platform
+
+::: warning Requires BSI 4.1.0 or later
+In earlier versions this command could report that it had removed a browser while the browser was still on disk. It printed a success message, exited with code 0, and left the files in place.
+:::
+
+The BSI cache labels each browser with the platform it was built for — `win64`, `mac_arm`, `linux`, and so on. A cache can hold builds for another platform in several ordinary ways:
+
+- The cache directory was copied from one machine to another, for example when preparing an offline server.
+- The cache is on a shared or network drive used by more than one machine.
+- The cache is mounted into a Docker container from a host running a different operating system.
+
+Such builds **can** be removed — a browser you cannot run still takes up disk space. From 4.1.0 the removal actually happens, and the result is verified before success is reported.
+
+When removal fails, the command says so and exits with a non-zero code, so a scheduled job can detect it:
+
+```
+error: Browser "chrome", version "151.0.7922.47" (built for win64) could not be removed. It is still in the cache at C:\Users\goran\.cache\puppeteer\chrome\win64-151.0.7922.47.
+```
+
+When the same version is cached for more than one platform, the build that can run on the current machine is removed first, and the ambiguity is reported:
+
+```
+warn: Build 151.0.7922.47 is cached for 2 platforms (win64, mac_arm). Removing the "win64" build; re-run to remove the next one.
+```
+
+Run the command again to remove the second one.
+
+::: tip Worth checking once
+If you have previously cleaned up browsers on a machine, run `browser list-installed` to check whether builds you believed were deleted are still there. If they are, `browser uninstall` will now remove them properly.
+:::
 
 ### uninstall-all
 


### PR DESCRIPTION
Release merge of `next` into `main`, publishing the documentation for **Butler Sheet Icons 4.1.0** to <https://butler-sheet-icons.ptarmiganlabs.com>.

### Release precondition

BSI **v4.1.0** was released 2026-08-11, so `releases/latest` already points at the new version and the production nav label will pick it up on this build. Every behaviour documented here is in a shipped release (4.0.0 or 4.1.0) — nothing describes unreleased functionality.

### New page

| Page | Content |
|---|---|
| `/guide/interactive-mode` | Interactive mode (4.1.0): the browser install and uninstall wizards, picking a version from a list instead of typing it, and how to leave a wizard. Added to the sidebar in `config.js`. |

### Edited pages

| Page | Change |
|---|---|
| `/guide/advanced/docker` | What is inside the image and where its licences are — `/nodeapp/licenses/`, the Chromium credits page, the Alpine package database, and the H.264/AAC patent-pool note. Plus air-gapped transfer and internal-registry mirroring. |
| `/guide/advanced/crash-dumps` | The per-run dump cap (`BSI_CRASH_DUMP_MAX_PER_PROCESS`, default 10) and how to clean up dumps left by older versions. |
| `/guide/concepts/environment-variables` | Log colour now follows terminal detection rather than always being emitted, with before/after output. |
| `/guide/concepts/sheet-blurring` | `--blur-sheet-tag` works on QSEoW; the old "not yet implemented" log line is gone, so log filters matching it need removing. |
| `/guide/concepts/sheet-parts` | `--includesheetpart` is validated at parse time, with the valid values per back end. |
| `/guide/troubleshooting` | New section on the five options and messages that told you the wrong thing, and their workarounds. |
| `/reference/browser` | `browser uninstall` now reports truthfully what it removed, including the multi-platform ambiguity warning. |
| `/examples/docker` | Cross-links to the licence section. |

### Version gates

All gates in this diff were verified against `ptarmiganlabs/butler-sheet-icons` with `git tag --contains`, not release notes. Five were corrected in #66 immediately before this merge — one of them named 4.0.1, a version that was never released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)