### PR TITLE
fix: resolve the version without a token, and never ship v0.0.0 to production

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -130,14 +130,27 @@ the same pull request. A release tracking 3.12.0 became 4.0.0 that way when two 
 changes arrived, after several pages had already been written against 3.12.0. Reading it
 per build is what makes the label self-correcting.
 
-Every lookup degrades rather than failing the build: pending version → latest release →
-the previously generated `version.js` → `v0.0.0`.
+The chain is: pending version (preview only) → latest release from the API → latest
+release from `github.com` → the previously generated `version.js` → `v0.0.0`.
+
+The `github.com` step needs no authentication: `/releases/latest` on the website is a 302
+to `/releases/tag/<tag>`, so the tag arrives in the `Location` header at no API quota
+cost. It is what keeps the label correct when `GITHUB_TOKEN` is missing, invalid or rate
+limited, which is the failure this site actually hits.
+
+> [!IMPORTANT]
+> **On production the chain does not end at `v0.0.0` — it fails the build.** Publishing
+> `v0.0.0` is wrong, publicly visible and completely silent: the build succeeds, Cloudflare
+> deploys, and nothing surfaces the problem until somebody looks at the nav. A failed build
+> is louder and cheaper to notice. Set `BSI_DOCS_VERSION` to publish anyway if GitHub is
+> unreachable during a release. Preview and local builds still degrade to `v0.0.0`, so
+> working offline and on a plane still builds.
 
 Environment variables that affect this:
 
 | Variable | Where | Effect |
 | --- | --- | --- |
-| `GITHUB_TOKEN` (or `GH_TOKEN`) | Cloudflare project, CI, local | Authenticates the API calls. **Recommended in Cloudflare.** Build IPs are shared, so the 60 req/hour anonymous limit is reachable; because `version.js` is git-ignored, a fresh build container has no previous file to fall back on and the nav silently renders `v0.0.0`. |
+| `GITHUB_TOKEN` (or `GH_TOKEN`) | Cloudflare project, CI, local | Authenticates the API calls. **Optional** — the `github.com` fallback covers its absence. Worth setting anyway: build IPs are shared, so the 60 req/hour anonymous limit is reachable and the fallback then carries every build. Only needs read access to a public repo, so an unscoped token is enough. A `403` in the build log means it is missing or rate limited; a `401` means the value is wrong. |
 | `CF_PAGES_BRANCH` | Set by Cloudflare Pages | Read, not set by us. Decides production vs preview behaviour above. |
 | `BSI_DOCS_VERSION` | Anywhere | **Escape hatch, normally unset.** Overrides everything and never falls back. Only useful to pin a label the automation cannot work out. A stale value here silently defeats the automation. |
 
@@ -174,7 +187,8 @@ Export `GITHUB_TOKEN` locally to avoid anonymous API rate limits on the version 
 
 | Symptom | Cause / action |
 | --- | --- |
-| Nav shows `v0.0.0` | Version lookup failed and no cached file existed. Set `GITHUB_TOKEN` in the Cloudflare project. |
+| Nav shows `v0.0.0` | Only possible on a preview or local build — production fails instead. Every lookup failed, including the unauthenticated `github.com` one, so the machine most likely had no outbound network. |
+| Production build fails on the version lookup | Both GitHub lookups failed. Read the `[bsi-docs]` warnings above the error: `403` means `GITHUB_TOKEN` is missing or rate limited, `401` means it is wrong. To publish while GitHub is unreachable, set `BSI_DOCS_VERSION` — and remove it afterwards. |
 | Nav shows the wrong version on a `next` preview | Check the build log for the `[bsi-docs]` lines. They name the branch, whether it was treated as a preview, and which release PR was read. A stale `BSI_DOCS_VERSION` overriding everything is the most likely cause. |
 | Change not live on production | Check the "Cloudflare Pages" check run on the commit. Confirm the commit is on `main`, not `next`. |
 | Build fails on a dead link | VitePress names the offending file and link. Internal links are absolute and extensionless: `/guide/concepts/browser-management`. |

--- a/scripts/fetch-bsi-version.mjs
+++ b/scripts/fetch-bsi-version.mjs
@@ -30,6 +30,9 @@ const REPO = "butler-sheet-icons";
 const API_ROOT = `https://api.github.com/repos/${OWNER}/${REPO}`;
 const LATEST_RELEASE_URL = `${API_ROOT}/releases/latest`;
 
+/** Website equivalent of LATEST_RELEASE_URL. Redirects to the tag, and costs no API quota. */
+const RELEASES_LATEST_WEB_URL = `https://github.com/${OWNER}/${REPO}/releases/latest`;
+
 /**
  * Branch release-please keeps its pending release on. The name is derived from its
  * config — `release-please--branches--<target>--components--<component>` — and is
@@ -110,6 +113,11 @@ function isPreviewBuild() {
   return branch !== "" && branch !== PRODUCTION_BRANCH;
 }
 
+/** True only on the Cloudflare build that publishes the public site. */
+function isProductionBuild() {
+  return currentBranch() === PRODUCTION_BRANCH;
+}
+
 /**
  * Asks release-please what the next version will be.
  *
@@ -159,7 +167,52 @@ async function fetchLatestReleaseVersion() {
   return normalizeTag(rawTag);
 }
 
-/** Keeps a previously generated file if there is one, otherwise writes a safe default. */
+/**
+ * Same answer as fetchLatestReleaseVersion, read from github.com instead of the API.
+ *
+ * `/releases/latest` on the website is a 302 to `/releases/tag/<tag>`, so the tag comes
+ * back in the Location header. This costs no API quota, which is the whole point: the
+ * API's anonymous limit is 60 req/hour against shared Cloudflare build IPs, and a
+ * missing or invalid GITHUB_TOKEN is otherwise indistinguishable from success — both
+ * end at the v0.0.0 fallback. This path keeps production correct without a token.
+ *
+ * Only useful for a public repository, which this one is.
+ */
+async function fetchLatestReleaseVersionViaRedirect() {
+  const res = await fetch(RELEASES_LATEST_WEB_URL, {
+    redirect: "manual",
+    headers: { "User-Agent": "bsi-docs-build-script" },
+  });
+
+  const location = res.headers.get("location");
+  if (!location) {
+    throw new Error(`No redirect from ${RELEASES_LATEST_WEB_URL} (${res.status})`);
+  }
+
+  // A repo with no releases redirects to /releases, which carries no tag.
+  const marker = "/releases/tag/";
+  const index = location.indexOf(marker);
+  if (index === -1) {
+    throw new Error(`Redirect carried no release tag: ${location}`);
+  }
+
+  const rawTag = decodeURIComponent(location.slice(index + marker.length));
+  if (!isValidTag(rawTag)) {
+    throw new Error(`Redirect carried an unusable tag: ${location}`);
+  }
+
+  return normalizeTag(rawTag);
+}
+
+/**
+ * Keeps a previously generated file if there is one, otherwise writes a safe default.
+ *
+ * On production there is no safe default. `v0.0.0` in the nav is wrong, publicly visible,
+ * and silent — the site builds and deploys perfectly well while showing it, so nothing
+ * surfaces the failure until someone happens to look at the nav. Failing the build is
+ * louder and cheaper to notice. Set BSI_DOCS_VERSION to publish anyway if GitHub is down
+ * during a release.
+ */
 async function writeFallbackVersion() {
   try {
     const existing = await fs.readFile(outFile, "utf8");
@@ -168,6 +221,15 @@ async function writeFallbackVersion() {
       return;
     }
   } catch {}
+
+  if (isProductionBuild()) {
+    throw new Error(
+      "Could not determine the version to show, and this is a production build. " +
+        "Refusing to publish v0.0.0 to the public site. Check the warnings above: a 401 " +
+        "means GITHUB_TOKEN is invalid, a 403 means it is missing or rate limited. " +
+        "Set BSI_DOCS_VERSION to a known version to publish anyway."
+    );
+  }
 
   const fallback = "v0.0.0";
   await writeVersionFile(fallback);
@@ -212,12 +274,30 @@ async function main() {
     const tag = await fetchLatestReleaseVersion();
     await writeVersionFile(tag);
     console.log(`[bsi-docs] Latest ${REPO} version: ${tag}`);
+    return;
   } catch (err) {
     console.warn(
-      `[bsi-docs] Warning: Could not fetch latest release tag: ${err.message}`
+      `[bsi-docs] Warning: Could not fetch latest release tag from the API: ${err.message}`
     );
-    await writeFallbackVersion();
   }
+
+  // The API call above is the one that needs a token. This one does not, so it is what
+  // keeps the label right when the token is missing, invalid, or rate limited.
+  try {
+    const tag = await fetchLatestReleaseVersionViaRedirect();
+    await writeVersionFile(tag);
+    console.log(`[bsi-docs] Latest ${REPO} version, via github.com: ${tag}`);
+    return;
+  } catch (err) {
+    console.warn(
+      `[bsi-docs] Warning: Could not read the release redirect either: ${err.message}`
+    );
+  }
+
+  await writeFallbackVersion();
 }
 
-main();
+main().catch((err) => {
+  console.error(`[bsi-docs] ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Production has been serving `v0.0.0` in the nav instead of `v4.1.0`. The retried build log gives the cause:

```
[bsi-docs] Branch: main, preview: false
[bsi-docs] Warning: Could not fetch latest release tag: GitHub API failed with 403 Forbidden
[bsi-docs] Wrote fallback version v0.0.0
```

**403, not 401** — an invalid token returns 401, so no token reached the build at all and the anonymous 60 req/hour limit on shared Cloudflare build IPs was already spent. `version.js` is git-ignored and the build cache is disabled, so a fresh container had no previous file to fall back on.

This has been intermittent for a while: `d4044b3` → v0.0.0, `159e93e` → v4.0.0, `dfd280c` → v0.0.0. Which is the real problem — it is a coin flip nobody was checking.

## Resolve the version without authentication

`/releases/latest` on **github.com** (not `api.github.com`) is a 302 to `/releases/tag/<tag>`:

```
location: https://github.com/ptarmiganlabs/butler-sheet-icons/releases/tag/butler-sheet-icons-v4.1.0
```

The tag arrives in the `Location` header at no API quota cost. Tried after the API call fails. The repo is public, so this needs no credentials — `GITHUB_TOKEN` becomes an optimisation rather than a dependency.

## Fail production instead of publishing v0.0.0

The old behaviour was silent: build succeeds, Cloudflare deploys, nothing surfaces the problem until somebody looks at the nav. That silence is why this survived several releases.

Production now exits 1 with a message naming the likely cause. `BSI_DOCS_VERSION` still publishes anyway if GitHub is unreachable during a release. Preview and local builds keep degrading to `v0.0.0`, so offline work still builds.

## Verification

Every path exercised. An invalid token reproduces the production failure exactly, since the redirect call sends no auth:

| # | Scenario | Result |
|---|---|---|
| 1 | Normal, no token | `v4.1.0` |
| 2 | Invalid token → API 401 | `v4.1.0` via github.com |
| 3 | `BSI_DOCS_VERSION` override | `v9.9.9`, wins as before |
| 4 | **Production + API auth failure** | `v4.1.0` via github.com, exit 0 |
| 5 | Production + both lookups dead | **exit 1**, no `version.js` written |
| 6 | Preview + both lookups dead | `v0.0.0`, exit 0 |
| 7 | Local offline | `v0.0.0`, exit 0 |

`npm run docs:build` passes and resolves `v4.1.0`.

## Note

This only reaches the public site once `next` is merged to `main`. `README_DEPLOY.md` is updated for the new chain, the production failure mode, and the 401-vs-403 distinction.

Setting `GITHUB_TOKEN` in Cloudflare is still worth doing so the fallback is not carrying every build — but it is no longer required for a correct site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)