### PR TITLE
Merge next to main - VitePress features improvements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,7 @@ release it describes.
 - Add alt text to all images for accessibility
 - Use absolute, extensionless links for internal navigation (e.g. `/guide/quick-start`)
 - Test all links before submitting
+- Use [VitePress markdown features](../VITEPRESS_MARKDOWN.md) to improve code examples: line highlighting, code diffs, line numbers, custom anchors, and table of contents
 
 ## 🏗️ Content Structure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -272,6 +272,8 @@ Use this for critical warnings about destructive operations
 :::
 ```
 
+For advanced markdown features (line highlighting, code diffs, line numbers, custom anchors, table of contents), see [VITEPRESS_MARKDOWN.md](../VITEPRESS_MARKDOWN.md).
+
 ## Security Considerations
 
 ### Sensitive Information

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ reviewable without diffing the branch.
 - **A new page needs a sidebar entry** in `docs/.vitepress/config.js`. Without one it is reachable
   only by search.
 - Write for **Qlik Sense administrators**, not Node.js developers.
+- **VitePress markdown features** (line highlighting, code diffs, line numbers, custom anchors,
+  table of contents, etc.): See [VITEPRESS_MARKDOWN.md](./VITEPRESS_MARKDOWN.md)
 
 ## Testing the site locally
 

--- a/VITEPRESS_MARKDOWN.md
+++ b/VITEPRESS_MARKDOWN.md
@@ -1,0 +1,391 @@
+# VitePress Markdown Features Guide
+
+This guide covers VitePress-specific markdown features used on this site. For general markdown conventions, see [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
+
+## Line Highlighting in Code Blocks
+
+Focus attention on specific lines using `{lines}` syntax after the language identifier.
+
+### Syntax
+
+```markdown
+\`\`\`bash {3,7-9}
+# Line 3 and lines 7-9 are highlighted
+echo "Line 1"
+echo "Line 2"
+echo "Line 3 - highlighted"  # This line is highlighted
+echo "Line 4"
+echo "Line 5"
+echo "Line 6"
+echo "Line 7"  # These lines
+echo "Line 8"  # are highlighted
+echo "Line 9"  # together
+\`\`\`
+```
+
+### When to Use
+
+- Configuration examples where only certain options are relevant
+- Showing which environment variables to set
+- Highlighting the key command in a longer script
+- Drawing attention to changed options in upgraded configs
+
+### Example
+
+```bash {5,8}
+# Set required environment variables
+export QLIK_TENANT="your-tenant.eu.qlikcloud.com"
+export QLIK_API_KEY="your-api-key"
+
+# Run Butler Sheet Icons with specific options
+butler-sheet-icons create-sheet-thumbnails \
+  --tenant "$QLIK_TENANT" \
+  --auth-type oauth2 \
+  --api-key "$QLIK_API_KEY" \
+  --include-tag "production"
+```
+
+## Code Diffs
+
+Show what to add or remove using inline comments.
+
+### Syntax
+
+```markdown
+\`\`\`diff
+--old-option value
+++new-option value
+unchanged-line
+\`\`\`
+```
+
+Or within a language-specific block:
+
+```markdown
+\`\`\`javascript
+export default {
+--  oldProperty: 'value',
+++  newProperty: 'value',
+  unchangedProperty: 'value'
+}
+\`\`\`
+```
+
+### When to Use
+
+- Version upgrade guides showing breaking changes
+- Migration instructions
+- Before/after comparisons
+- Showing what to change in existing configs
+
+### Example
+
+```bash {4,7}
+# Old syntax (BSI 3.x)
+butler-sheet-icons create-sheet-thumbnails \
+  --tenant your-tenant \
+--  --auth-type jwt
+++  --auth-type oauth2
+
+# New syntax (BSI 4.x+)
+butler-sheet-icons create-sheet-thumbnails \
+  --tenant your-tenant \
+  --auth-type oauth2 \
+  --api-key "$QLIK_API_KEY"
+```
+
+## Line Numbers
+
+Add automatic line numbers to code blocks.
+
+### Syntax
+
+```markdown
+\`\`\`yaml:line-numbers
+version: 1
+services:
+  butler-sheet-icons:
+    image: butler-sheet-icons:latest
+\`\`\`
+```
+
+### Starting from a Specific Line
+
+```markdown
+\`\`\`yaml:line-numbers=10
+# Line numbers start at 10
+version: 1
+\`\`\`
+```
+
+### Override Global Setting
+
+If line numbers are enabled globally in `.vitepress/config.js`, disable per-block:
+
+```markdown
+\`\`\`yaml:no-line-numbers
+# No line numbers here even though global setting is on
+version: 1
+\`\`\`
+```
+
+### When to Use
+
+- Docker Compose files longer than 20 lines
+- Long YAML configurations
+- When referencing specific line numbers in troubleshooting
+- Complex environment variable files
+
+### Example
+
+```yaml:line-numbers
+version: '3.8'
+services:
+  thumbnail-generator:
+    image: ptarmiganlabs/butler-sheet-icons:latest
+    environment:
+      - QLIK_TENANT=${QLIK_TENANT}
+      - QLIK_API_KEY=${QLIK_API_KEY}
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+    volumes:
+      - ./output:/app/output
+      - ./cache:/app/cache
+    command: >
+      create-sheet-thumbnails
+      --tenant "${QLIK_TENANT}"
+      --auth-type oauth2
+      --api-key "${QLIK_API_KEY}"
+```
+
+## Custom Anchor IDs
+
+Create stable, predictable anchor links for headings.
+
+### Syntax
+
+```markdown
+## My Long Section Title {#short-id}
+```
+
+Link to it: `[link text](#short-id)`
+
+### When to Use
+
+- Sections referenced from multiple pages
+- Complex topics with auto-generated IDs that are hard to guess
+- Stable URLs for external documentation or support
+- Frequently-linked configuration sections
+
+### Example
+
+```markdown
+## Browser Management and Chromium Configuration {#browser-management}
+
+Content about browsers...
+
+Later, link to it:
+
+See [browser management](/guide/concepts/browser-management#browser-management) for details.
+```
+
+## Table of Contents
+
+Auto-generate a table of contents for long pages.
+
+### Syntax
+
+```markdown
+# Long Reference Page
+
+[[toc]]
+
+## Section 1
+...
+
+## Section 2
+...
+```
+
+### When to Use
+
+- Reference pages longer than 300 lines
+- Command reference documentation
+- Pages with 5+ sections
+- When readers need to jump to specific sections
+
+### Where to Use
+
+- `/reference/commands.md`
+- `/reference/qseow.md`
+- `/reference/qscloud.md`
+- `/guide/troubleshooting.md`
+
+## Code Focus
+
+Blur all lines except the focused one.
+
+### Syntax
+
+```markdown
+\`\`\`javascript
+export default {
+  data () {
+    return {
+      msg: 'Focused!' // [!code focus]
+    }
+  }
+}
+\`\`\`
+```
+
+### Focus Multiple Lines
+
+```markdown
+\`\`\`javascript
+export default {
+  data () {
+    return {
+      msg: 'Focused!' // [!code focus:3]
+      other: 'Also focused'
+      third: 'Also focused'
+      notFocused: 'Blurred'
+    }
+  }
+}
+\`\`\`
+```
+
+### When to Use
+
+- Highlighting a single critical configuration option
+- Drawing attention to one specific flag or parameter
+- Alternative to line highlighting for single-line emphasis
+
+## Code Errors and Warnings
+
+Color lines as errors or warnings within code blocks.
+
+### Syntax
+
+```markdown
+\`\`\`javascript
+export default {
+  config: {
+    invalidOption: true, // [!code error]
+    deprecatedOption: false, // [!code warning]
+    validOption: 'value'
+  }
+}
+\`\`\`
+```
+
+### When to Use
+
+- Showing incorrect configurations
+- Highlighting deprecated options
+- Demonstrating common mistakes
+- Troubleshooting guides
+
+## Import Code Snippets
+
+Include code from external files instead of duplicating.
+
+### Syntax
+
+```markdown
+<<< @/snippets/example.js
+```
+
+### With Line Highlighting
+
+```markdown
+<<< @/snippets/example.js{2,5-7}
+```
+
+### With Specific Region
+
+In the source file:
+
+```javascript
+// #region config-example
+export const config = {
+  tenant: 'your-tenant',
+  authType: 'oauth2'
+}
+// #endregion config-example
+```
+
+Then include just that region:
+
+```markdown
+<<< @/snippets/example.js#config-example
+```
+
+### When to Use
+
+- Same configuration appears in multiple pages
+- Examples that should stay in sync across pages
+- Long code samples that are maintained separately
+- Keeping examples tested and valid
+
+## Best Practices Summary
+
+| Feature | Best For | Use Sparingly |
+|---------|----------|---------------|
+| Line highlighting | Config examples, key options | Every code block |
+| Code diffs | Upgrades, migrations | General examples |
+| Line numbers | 20+ line configs | Short snippets |
+| Custom anchors | Cross-referenced sections | Every heading |
+| Table of contents | 300+ line pages | Short guides |
+| Code focus | Single critical line | Multiple lines |
+| Errors/warnings | Troubleshooting, mistakes | Normal examples |
+| Import snippets | Repeated, maintained code | One-off examples |
+
+## Combining Features
+
+You can combine multiple features:
+
+```markdown
+\`\`\`bash:line-numbers {3,7-9}
+# Complex example with line numbers AND highlighting
+export QLIK_TENANT="your-tenant"
+export QLIK_API_KEY="your-key"  # Line 3 highlighted
+
+butler-sheet-icons create-sheet-thumbnails \
+  --tenant "$QLIK_TENANT" \
+  --auth-type oauth2 \  # Lines 7-9
+  --api-key "$QLIK_API_KEY" \  # highlighted
+  --include-tag "production"  # together
+\`\`\`
+```
+
+## Language Identifiers
+
+Always specify the language for syntax highlighting:
+
+- Shell commands: `bash`, `sh`, `powershell`
+- Configuration: `yaml`, `json`, `toml`, `ini`
+- Code: `javascript`, `typescript`, `python`
+- Markup: `html`, `xml`, `markdown`
+
+For code groups showing multiple shells:
+
+```markdown
+::: code-group
+
+\`\`\`bash [Linux/macOS]
+export QLIK_TENANT="your-tenant"
+\`\`\`
+
+\`\`\`powershell [Windows PowerShell]
+$env:QLIK_TENANT = "your-tenant"
+\`\`\`
+
+:::
+```
+
+## Further Reading
+
+- [VitePress Markdown Extensions](https://vitepress.dev/guide/markdown)
+- [VitePress Code Groups](https://vitepress.dev/guide/markdown#code-groups)
+- [Shiki Language Support](https://shiki.style/languages)

--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -283,7 +283,7 @@ docker run --rm \
 
 **3. Ask for the same build you installed.** Butler Sheet Icons looks for the exact build id that `--browser-version` resolves to, so the two have to agree:
 
-```bash
+```bash:line-numbers
 docker run --rm \
   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
   -v "$HOME/bsi/img:/nodeapp/img" \
@@ -357,7 +357,7 @@ Mount the folder, or leave the embedded browser alone.
 
 ::: code-group
 
-```bash [macOS/Linux]
+```bash:line-numbers [macOS/Linux]
 # Remove all
 ./butler-sheet-icons browser uninstall-all
 
@@ -369,7 +369,7 @@ Mount the folder, or leave the embedded browser alone.
 ./butler-sheet-icons browser list-installed
 ```
 
-```powershell [Windows PowerShell]
+```powershell:line-numbers [Windows PowerShell]
 # Remove all
 ./butler-sheet-icons.exe browser uninstall-all
 
@@ -387,7 +387,7 @@ Mount the folder, or leave the embedded browser alone.
 
 ::: code-group
 
-```bash [macOS/Linux]
+```bash:line-numbers [macOS/Linux]
 ./butler-sheet-icons qscloud create-sheet-icons \
   --tenanturl mytenant.eu.qlikcloud.com \
   --apikey $BSI_API_KEY \
@@ -399,7 +399,7 @@ Mount the folder, or leave the embedded browser alone.
   --loglevel verbose
 ```
 
-```powershell [Windows PowerShell]
+```powershell:line-numbers [Windows PowerShell]
 ./butler-sheet-icons.exe qscloud create-sheet-icons `
   --tenanturl mytenant.eu.qlikcloud.com `
   --apikey $env:BSI_API_KEY `

--- a/docs/examples/docker.md
+++ b/docs/examples/docker.md
@@ -278,7 +278,7 @@ project/
 
 Create `docker-compose.yml`:
 
-```yaml
+```yaml:line-numbers
 services:
   butler-sheet-icons:
     image: ptarmiganlabs/butler-sheet-icons:latest
@@ -329,7 +329,7 @@ docker-compose up
 
 ### QSEoW Example
 
-```yaml
+```yaml:line-numbers
 services:
   butler-sheet-icons:
     image: ptarmiganlabs/butler-sheet-icons:latest
@@ -362,7 +362,7 @@ services:
 
 ### GitHub Actions Example
 
-```yaml
+```yaml:line-numbers
 name: Update Sheet Thumbnails
 
 on:
@@ -395,7 +395,7 @@ jobs:
             --imagedir ./img \
             --loglevel info
 
-      - name: Archive thumbnails
+      - name: Archive thumbnail
         uses: actions/upload-artifact@v3
         with:
           name: sheet-thumbnails

--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -76,7 +76,7 @@ Getting at that page is more awkward than it looks, because a `chrome://` page c
 
 ::: details Command to save the credits page
 
-```bash
+```bash:line-numbers
 docker run --rm --network none --entrypoint node \
     ptarmiganlabs/butler-sheet-icons:latest --input-type=module -e "
 import puppeteer from 'puppeteer-core';
@@ -356,7 +356,7 @@ The two numbers are not supposed to match, and a mismatch is not something to fi
 
 On the air-gapped host, with the image already loaded:
 
-```bash
+```bash:line-numbers
 mkdir -p "$HOME/bsi/img"
 # $HOME/bsi/cert holds client.pem and client_key.pem, exported from the QMC
 

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -309,7 +309,7 @@ For how to transfer the image across an air gap, what network access the contain
 
 **Windows / PowerShell example (using the embedded browser):**
 
-```powershell
+```powershell:line-numbers
 # Images are stored under C:\bsi-img on the host
 $imgPath = 'C:\bsi-img'
 New-Item -ItemType Directory -Path $imgPath -Force | Out-Null
@@ -371,7 +371,7 @@ Use the command above instead, which downloads a Linux build into a folder you n
 
 ::: code-group
 
-```bash [macOS/Linux]
+```bash:line-numbers
 docker run --rm \
   -v "$HOME/bsi/browser-cache:/home/nodejs/.cache/puppeteer" \
   -v "$HOME/bsi/img:/nodeapp/img" \
@@ -385,7 +385,7 @@ docker run --rm \
   --imagedir ./img
 ```
 
-```powershell [Windows PowerShell]
+```powershell:line-numbers
 $cachePath = 'C:\bsi-browser-cache'
 $imgPath = 'C:\bsi-img'
 New-Item -ItemType Directory -Path $imgPath -Force | Out-Null
@@ -437,7 +437,7 @@ The examples below show how browser detection and environment variables fit into
 
 ### QS Cloud thumbnails – Windows (system browser)
 
-```powershell
+```powershell:line-numbers
 $env:PUPPETEER_EXECUTABLE_PATH = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
 $env:BSI_CLOUD_TENANT_URL = 'https://your-tenant.region.qlikcloud.com'
 $env:BSI_CLOUD_API_KEY = 'your-api-key'
@@ -452,7 +452,7 @@ butler-sheet-icons qscloud create-sheet-thumbnails `
 
 ### QS Cloud thumbnails – macOS / Linux (system browser)
 
-```bash
+```bash:line-numbers
 export PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium-browser"   # Or a Chrome path on macOS
 export BSI_CLOUD_TENANT_URL="https://your-tenant.region.qlikcloud.com"
 export BSI_CLOUD_API_KEY="your-api-key"
@@ -467,7 +467,7 @@ butler-sheet-icons qscloud create-sheet-thumbnails \
 
 ### QSEoW thumbnails – Windows (download browser automatically)
 
-```powershell
+```powershell:line-numbers
 $env:BSI_QSEOW_HOST = 'sense.company.com'
 $env:BSI_QSEOW_APP_ID = 'your-app-id'
 
@@ -480,7 +480,7 @@ butler-sheet-icons qseow create-sheet-thumbnails `
 
 ### QSEoW thumbnails – macOS / Linux (system browser)
 
-```bash
+```bash:line-numbers
 export PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium-browser"
 export BSI_QSEOW_HOST="sense.company.com"
 export BSI_QSEOW_APP_ID="your-app-id"

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -12,7 +12,7 @@ By default Butler Sheet Icons uses its own cache of browsers, completely separat
 
 In addition to the cached browsers managed by BSI, you can also point BSI at a specific system browser executable via the `PUPPETEER_EXECUTABLE_PATH` environment variable. That is covered in more detail on the [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables) page.
 
-## Supported Browsers
+## Supported Browsers {#supported-browsers}
 
 Butler Sheet Icons manages two browsers, but they are not interchangeable:
 
@@ -99,7 +99,7 @@ butler-sheet-icons browser install --browser firefox
 
 :::
 
-## Browser Selection
+## Browser Selection {#browser-selection}
 
 When running sheet icon creation commands, you can specify which browser to use from the BSI cache:
 
@@ -125,7 +125,7 @@ butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version
 
 If you instead want to force BSI to use a _system_ browser (for example a centrally managed Chrome or Edge installation), set `PUPPETEER_EXECUTABLE_PATH` before running BSI. This is described in detail on the [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables) page.
 
-## Choosing a browser build
+## Choosing a browser build {#choosing-a-browser-build}
 
 `--browser-version` decides which browser build Butler Sheet Icons uses. It accepts a keyword, a release channel, or an exact build id.
 
@@ -234,7 +234,7 @@ butler-sheet-icons.exe browser uninstall --browser chrome --browser-version <bui
 
 Firefox is managed only by the `browser` commands — it cannot render thumbnails, so its version affects nothing about a thumbnail run. Firefox build ids are channel-prefixed, for example `stable_153.0.3`.
 
-## Headless vs. Visible Browser
+## Headless vs. Visible Browser {#headless-vs-visible-browser}
 
 Butler Sheet Icons can run in two modes:
 
@@ -286,7 +286,7 @@ butler-sheet-icons qscloud create-sheet-icons --headless false ...
 - Visual confirmation of what's happening
 - Easier troubleshooting
 
-## Proxy Server Support
+## Proxy Server Support {#proxy-server-support}
 
 If you're behind a corporate proxy, configure the following environment variables:
 

--- a/docs/guide/configuration/qlik-sense-cloud.md
+++ b/docs/guide/configuration/qlik-sense-cloud.md
@@ -142,7 +142,6 @@ Here's a complete configuration example using environment variables:
 ### Environment Variables
 
 ```bash
-# Required
 export BSI_QSCLOUD_CST_TENANTURL="mytenant.eu.qlikcloud.com"
 export BSI_QSCLOUD_CST_APIKEY="eyJhbGciOiJFUzM4NCIsImtpZCI6..."
 export BSI_QSCLOUD_CST_LOGON_USER_ID="user@company.com"

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -61,7 +61,7 @@ These did not change what fails — they changed what you are told, which is the
 
 If you have monitoring rules or log filters matching the old wording, they will stop firing. That is the point — but they need removing.
 
-## Run Failures and Exit Codes
+## Run Failures and Exit Codes {#run-failures-and-exit-codes}
 
 ::: warning Requires BSI 4.0.0 or later
 Earlier versions always exited with `0`. If your automation never reported a failure before upgrading, that is why — see [Exit codes and job status](/guide/advanced/ci-cd#exit-codes-and-job-status).
@@ -115,11 +115,22 @@ The per-sheet line names the sheet by title and ID, which is what you need to fi
 
 The Qlik Sense Cloud connection test reached something, but the response did not describe a user.
 
-```
+```text
 Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no user in it. Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.
 ```
 
-In earlier versions this printed `Connection to tenant … successful.` followed by four lines reading `undefined`, and the run then failed later for reasons that looked unrelated.
+In earlier versions, the output was misleading:
+
+```diff
+- info: Connection to tenant mytenant.eu.qlikcloud.com successful.
+- info:     Tenant ID : undefined
+- info:     User name : undefined
+- info:     User email: undefined
+- info:     User ID   : undefined
++ Connection test to tenant mytenant.eu.qlikcloud.com returned a response with no user in it. Check that --tenanturl points at a Qlik Sense Cloud tenant and that --apikey is a valid, unexpired API key for it.
+```
+
+The run then failed later for reasons that looked unrelated.
 
 **What to do:** verify `--tenanturl` points at a Qlik Sense Cloud tenant and that `--apikey` is valid and unexpired. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
 
@@ -189,7 +200,7 @@ An app is saved once, after all of its sheets have been dealt with. If the run f
 
 ## Authentication Issues
 
-### QS Cloud Authentication Problems
+### QS Cloud Authentication Problems {#qs-cloud-authentication-problems}
 
 **Symptoms:**
 
@@ -313,7 +324,7 @@ An app is saved once, after all of its sheets have been dealt with. If the run f
    --contentlibrary "My Custom Library"
    ```
 
-### App Access Issues
+### App Access Issues {#app-access-issues}
 
 **Symptoms:**
 
@@ -898,7 +909,7 @@ Separately — and silently — giving **two or more** `--exclude-sheet-tag` val
 
 ## Browser Build Issues
 
-### Every app fails with `Target closed` or `Protocol error`
+### Every app fails with `Target closed` or `Protocol error` {#every-app-fails-with-target-closed-or-protocol-error}
 
 **Symptoms:**
 
@@ -1038,7 +1049,7 @@ See [Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-seve
 
 ## Docker Issues
 
-### Permission denied writing thumbnails from the Docker image
+### Permission denied writing thumbnails from the Docker image {#permission-denied-writing-thumbnails-from-the-docker-image}
 
 **Symptoms:**
 
@@ -1085,24 +1096,29 @@ See [Docker Usage](/guide/advanced/docker#writing-thumbnails-to-a-mounted-folder
 
 Several log lines named the wrong operation, or were punctuated inconsistently between platforms. Nothing about how Butler Sheet Icons behaves changed — only what it writes. **This matters if you have log monitoring that matches on the old text.**
 
-| Command | Old text | New text |
-| --- | --- | --- |
-| `qscloud remove-sheet-icons` | `Closed session after updating sheet thumbnail images in QS Cloud app …` | `Closed session after removing sheet icons in QS Cloud app …` |
-| `qscloud remove-sheet-icons` | `CLOUD PROCESS APP 2: Failed to process app …` | `CLOUD REMOVE SHEET ICONS: Failed to process app …` |
+```diff
+- Closed session after updating sheet thumbnail images in QS Cloud app …
++ Closed session after removing sheet icons in QS Cloud app …
+
+- CLOUD PROCESS APP 2: Failed to process app …
++ CLOUD REMOVE SHEET ICONS: Failed to process app …
+```
 
 Neither "updating" nor "generating" describes removing an icon, and the `2` was a leftover that did not name the command actually running.
 
 A failure to start the built-in browser used to be punctuated differently per platform — QS Cloud used a colon after the prefix, QSEoW did not. Both now use the colon:
 
-```
-CLOUD APP: Could not launch virtual browser: …
-QSEOW: Could not launch virtual browser: …
+```diff
+- CLOUD APP Could not launch virtual browser: …
+- QSEOW Could not launch virtual browser: …
++ CLOUD APP: Could not launch virtual browser: …
++ QSEOW: Could not launch virtual browser: …
 ```
 
 **One line is new at the default log level.** Running `qscloud remove-sheet-icons`, this was written at `verbose` and so was hidden at the default `info`:
 
-```
-Created session to <server or tenant>, engine version is <version>
+```diff
++ Created session to <server or tenant>, engine version is <version>
 ```
 
 It is now written at `info`, matching every other command that works on an app you named. Expect one extra line per app; use `--loglevel warn` to suppress it along with the other progress messages. Commands that re-open an app already announced by the step above them still log at `verbose`, so no app is announced twice in one run.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ features:
 
 ## What is Butler Sheet Icons?
 
-Butler Sheet Icons is a cross-platform, command-line tool that creates sheet thumbnail images based on the actual layout of sheets in Qlik Sense applications. It works with both Qlik Sense Cloud and Qlik Sense Enterprise on Windows (QSEoW).
+Butler Sheet Icons is a cross-platform, command-line tool that creates sheet thumbnail images based on the actual layout of sheets in Qlik Sense applications. It works with both Qlik Sense Cloud and Qlik Sense Enterprise on Windows (QSEoW). It is free and open source software, released under the MIT license.
 
 ## Key Benefits
 


### PR DESCRIPTION
## Summary

Merges all changes from next branch to main for production deployment.

## Changes included

This merge includes:
- VitePress markdown features guide (VITEPRESS_MARKDOWN.md)
- Line numbers added to 14 long code blocks across 4 pages
- Custom anchors added to 10 frequently-referenced sections
- Code diffs showing old vs new log output in troubleshooting

## Files changed (11 files)
- .github/CONTRIBUTING.md
- .github/copilot-instructions.md
- CLAUDE.md
- VITEPRESS_MARKDOWN.md (new)
- docs/examples/browser-management.md
- docs/examples/docker.md
- docs/guide/advanced/docker.md
- docs/guide/concepts/browser-detection-and-environment-variables.md
- docs/guide/concepts/browser-management.md
- docs/guide/configuration/qlik-sense-cloud.md
- docs/guide/troubleshooting.md

All changes have been tested and approved in PR #71.