### PR TITLE
Generate the browser page's option tables instead of maintaining them by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,38 @@ reviewable without diffing the branch.
 - **VitePress markdown features** (line highlighting, code diffs, line numbers, custom anchors,
   table of contents, etc.): See [VITEPRESS_MARKDOWN.md](./VITEPRESS_MARKDOWN.md)
 
+## Generated option tables — do not edit between the markers
+
+Some pages carry CLI option tables wrapped in markers:
+
+```markdown
+<!-- generated:cli-options browser install -->
+
+| Option | Environment Variable | ... |
+...
+
+<!-- /generated:cli-options -->
+```
+
+**Everything between those two markers is generated and will be overwritten.** It is produced from
+the Commander definitions in the [butler-sheet-icons](https://github.com/ptarmiganlabs/butler-sheet-icons)
+repository, so the flag names, environment variables, accepted values and defaults on the page
+cannot drift from what the tool actually does. Editing inside the markers looks like it works and
+is silently undone on the next run.
+
+To change one of these tables, change the option declaration in `src/lib/commands/` in that repo —
+which corrects `butler-sheet-icons --help` at the same time — then regenerate from a checkout of
+it:
+
+```bash
+npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/browser.md --write
+```
+
+`--check` reports staleness without changing anything and exits non-zero. Prose outside the
+markers is never touched, so a page is normal markdown everywhere else.
+
+Pages using this today: `docs/reference/browser.md`.
+
 ## Testing the site locally
 
 You can run the site and look at it yourself. Do this whenever a change is visual, structural, or

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -43,10 +43,14 @@ butler-sheet-icons browser list-installed [options]
 
 **Options:**
 
-| Option                            | Environment Variable       | Description                                              | Default | Example            |
-| --------------------------------- | -------------------------- | -------------------------------------------------------- | ------- | ------------------ |
-| `--loglevel, --log-level <level>` | `BSI_BROWSER_LI_LOG_LEVEL` | Set log level (error, warn, info, verbose, debug, silly) | `info`  | `--loglevel debug` |
-| `-h, --help`                      | `-`                        | Display help for command                                 | `-`     | `-h`               |
+<!-- generated:cli-options browser list-installed -->
+
+| Option                            | Environment Variable       | Description                                                   | Default | Example            |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------- | ------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_LI_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly) | `info`  | `--loglevel error` |
+| `-h, --help`                      | -                          | display help for command                                      | -       | `-h`               |
+
+<!-- /generated:cli-options -->
 
 **Example Output (Windows):**
 
@@ -69,12 +73,16 @@ butler-sheet-icons browser list-available [options]
 
 **Options:**
 
-| Option                            | Environment Variable       | Description                                              | Default  | Example              |
-| --------------------------------- | -------------------------- | -------------------------------------------------------- | -------- | -------------------- |
-| `--loglevel, --log-level <level>` | `BSI_BROWSER_LA_LOG_LEVEL` | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel verbose` |
-| `--browser <browser>`             | `BSI_BROWSER_LA_BROWSER`   | Browser to check availability for (chrome, firefox)      | `chrome` | `--browser firefox`  |
-| `--channel <channel>`             | `BSI_BROWSER_LA_CHANNEL`   | Chrome release channel (stable, beta, dev, canary)       | `stable` | `--channel beta`     |
-| `-h, --help`                      | `-`                        | Display help for command                                 | `-`      | `--help`             |
+<!-- generated:cli-options browser list-available -->
+
+| Option                            | Environment Variable       | Description                                                                                                                                                      | Default  | Example             |
+| --------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_LA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                    | `info`   | `--loglevel error`  |
+| `--browser <browser>`             | `BSI_BROWSER_LA_BROWSER`   | Browser to list available versions for (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser install" to install one of them. (choices: chrome, firefox) | `chrome` | `--browser firefox` |
+| `--channel <channel>`             | `BSI_BROWSER_LA_CHANNEL`   | Which of the browser's release channel versions should be listed? This option is only used for Chrome. (choices: stable, beta, dev, canary)                      | `stable` | `--channel beta`    |
+| `-h, --help`                      | -                          | display help for command                                                                                                                                         | -        | `-h`                |
+
+<!-- /generated:cli-options -->
 
 **Example Output (macOS):**
 
@@ -117,12 +125,17 @@ butler-sheet-icons browser install [options]
 
 **Options:**
 
-| Option                            | Environment Variable            | Description                                              | Default  | Example                           |
-| --------------------------------- | ------------------------------- | -------------------------------------------------------- | -------- | --------------------------------- |
-| `--loglevel, --log-level <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel debug`                |
-| `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install (chrome, firefox)                     | `chrome` | `--browser firefox`               |
-| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Keyword (`recommended`, `stable`), channel, or build ID   | `recommended` | `--browser-version 121.0.6167.85` |
-| `-h, --help`                      | `-`                             | Display help for command                                 | `-`      | `--help`                          |
+<!-- generated:cli-options browser install -->
+
+| Option                            | Environment Variable            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Default       | Example             |
+| --------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------- |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                                                                                                                                                                                                                    | `info`        | `--loglevel error`  |
+| `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome, firefox)                                                                                                                                                                                                                                                                                       | `chrome`      | `--browser firefox` |
+| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Browser build to install. Either a keyword - "recommended" for the build Butler Sheet Icons is tested with, "stable" for the newest stable release, or a release channel such as "beta" - or an exact version. For Chrome that is a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"); for Firefox a channel-prefixed build id ("stable_153.0.3"). Use "butler-sheet-icons browser list-available" to see what is available. | `recommended` | -                   |
+| `-i, --interactive`               | -                               | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                                                                                                                                                                                                                                   | -             | -                   |
+| `-h, --help`                      | -                               | display help for command                                                                                                                                                                                                                                                                                                                                                                                                                                         | -             | `-h`                |
+
+<!-- /generated:cli-options -->
 
 **Examples:**
 
@@ -178,12 +191,17 @@ butler-sheet-icons browser uninstall [options]
 
 **Options:**
 
-| Option                            | Environment Variable             | Description                                              | Default  | Example                           |
-| --------------------------------- | -------------------------------- | -------------------------------------------------------- | -------- | --------------------------------- |
-| `--loglevel, --log-level <level>` | `BSI_BROWSER_UI_LOG_LEVEL`       | Set log level (error, warn, info, verbose, debug, silly) | `info`   | `--loglevel warn`                 |
-| `--browser <browser>`             | `BSI_BROWSER_UI_BROWSER`         | Browser to uninstall (chrome, firefox)                   | `chrome` | `--browser firefox`               |
-| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Exact build id, or `recommended`. Not `stable`/`latest`. | `-`      | `--browser-version 121.0.6167.85` |
-| `-h, --help`                      | `-`                              | Display help for command                                 | `-`      | `--help`                          |
+<!-- generated:cli-options browser uninstall -->
+
+| Option                            | Environment Variable             | Description                                                                                                                                                                                                                                                              | Default      | Example             |
+| --------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ------------------- |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_UI_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                            | `info`       | `--loglevel error`  |
+| `--browser <browser>`             | `BSI_BROWSER_UI_BROWSER`         | Browser to uninstall (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome, firefox)                                                                                             | **Required** | `--browser firefox` |
+| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Browser build to uninstall: an exact build id (for Chrome e.g. "151.0.7922.77", for Firefox e.g. "stable_153.0.3"), or "recommended" for the build Butler Sheet Icons is tested with. Use "butler-sheet-icons browser list-installed" to see which builds are installed. | **Required** | -                   |
+| `-i, --interactive`               | -                                | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                                           | -            | -                   |
+| `-h, --help`                      | -                                | display help for command                                                                                                                                                                                                                                                 | -            | `-h`                |
+
+<!-- /generated:cli-options -->
 
 **Example (Windows):**
 
@@ -253,10 +271,14 @@ butler-sheet-icons browser uninstall-all [options]
 
 **Options:**
 
-| Option                            | Environment Variable       | Description                                              | Default | Example           |
-| --------------------------------- | -------------------------- | -------------------------------------------------------- | ------- | ----------------- |
-| `--loglevel, --log-level <level>` | `BS_BROWSER_UIA_LOG_LEVEL` | Set log level (error, warn, info, verbose, debug, silly) | `info`  | `--loglevel info` |
-| `-h, --help`                      | `-`                        | Display help for command                                 | `-`     | `--help`          |
+<!-- generated:cli-options browser uninstall-all -->
+
+| Option                            | Environment Variable       | Description                                                   | Default | Example            |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------- | ------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BS_BROWSER_UIA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly) | `info`  | `--loglevel error` |
+| `-h, --help`                      | -                          | display help for command                                      | -       | `-h`               |
+
+<!-- /generated:cli-options -->
 
 **Example (macOS):**
 


### PR DESCRIPTION
The five option tables on the browser command reference are now generated from the Commander definitions in the butler-sheet-icons repository, delimited by `generated:cli-options` markers. Prose around the markers is untouched.

Regenerate from a butler-sheet-icons checkout:

```bash
npm run docs:cli-tables -- ../butler-sheet-icons-docs/docs/reference/browser.md --write
```

`--check` reports staleness without changing anything and exits non-zero, so it can gate a release.

## What the hand-written tables had drifted to

- `browser install` and `browser uninstall` were missing `-i, --interactive` **entirely** — an option that exists and is documented nowhere on this page.
- The flag is `--log-level, --loglevel`, in that order, not the reverse.
- Descriptions and accepted values now read exactly as `--help` prints them, so comparing the page against a terminal no longer shows differences that look like faults.

## Two fixes made at the source instead

`list-available` described `--browser` as installing (copied from the `install` command) and declared `--channel` as taking a `<browser>`. Both are corrected in butler-sheet-icons rather than here, which fixes `--help` and the interactive wizard prompt at the same time — see ptarmiganlabs/butler-sheet-icons#1021. This PR should land after that one, or the tables will not match.

## One thing deliberately left as-is

`uninstall-all` still shows `BS_BROWSER_UIA_LOG_LEVEL`, without the `I`. That is not drift — it is the name the code really reads, and this page was right about it all along. It is butler-sheet-icons#893. Regenerating after that fix lands updates this page on its own, which is rather the point.

## Verification

- `npm run docs:build` passes.
- Checked in a dev server: all five tables render as 5-column tables with no ragged rows, `--channel <channel>` is correct, both `-i, --interactive` rows are present, and no escaping backslashes are visible in the rendered text.

Sample command output on this page is still hand-maintained and still stale — that is butler-sheet-icons#849, which needs capturing from a released binary and is not touched here.