### PR TITLE
Chrome is the only browser Butler Sheet Icons uses

### DIFF
--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -31,7 +31,7 @@ Example output:
 2024-02-16T14:10:55.141Z info: App version: 3.2.3
 2024-02-16T14:10:55.141Z info: Installed browsers:
 2024-02-16T14:10:55.156Z info:     chrome, build id=121.0.6167.85, platform=mac, path=/Users/you/.cache/puppeteer/chrome/mac-121.0.6167.85
-2024-02-16T14:10:55.156Z info:     firefox, build id=124.0a1, platform=mac, path=/Users/you/.cache/puppeteer/firefox/mac-124.0a1
+2024-02-16T14:10:55.156Z info:     chrome, build id=151.0.7922.77, platform=mac, path=/Users/you/.cache/puppeteer/chrome/mac-151.0.7922.77
 ```
 
 ### Install default browser (latest Chrome)
@@ -56,20 +56,6 @@ Example output:
 2024-02-16T14:13:35.562Z info: Installing browser...
 2024-02-16T14:13:44.062Z info: Browser "chrome" version "121.0.6167.85" installed
 ```
-
-### Install Firefox (latest)
-
-::: code-group
-
-```bash [macOS/Linux]
-./butler-sheet-icons browser install --browser firefox
-```
-
-```powershell [Windows PowerShell]
-./butler-sheet-icons.exe browser install --browser firefox
-```
-
-:::
 
 ### List available Chrome builds (channels)
 
@@ -183,7 +169,7 @@ butler-sheet-icons qscloud create-sheet-icons \
 
 :::
 
-`chrome` is the only value the thumbnail commands accept. Firefox can be installed and removed with the `browser` commands, but cannot render thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
+`chrome` is the only value `--browser` accepts, on this and every other command — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers). It is also the default, so the option can be left out entirely.
 
 ### Use a specific browser version
 
@@ -333,22 +319,22 @@ Mount the folder, or leave the embedded browser alone.
 # Installed browsers
 ./butler-sheet-icons browser list-installed
 
-# Available Chrome builds
-./butler-sheet-icons browser list-available --browser chrome
+# Available Chrome builds on the stable channel
+./butler-sheet-icons browser list-available
 
-# Available Firefox builds
-./butler-sheet-icons browser list-available --browser firefox
+# Available Chrome builds on another channel
+./butler-sheet-icons browser list-available --channel beta
 ```
 
 ```powershell [Windows PowerShell]
 # Installed browsers
 ./butler-sheet-icons.exe browser list-installed
 
-# Available Chrome builds
-./butler-sheet-icons.exe browser list-available --browser chrome
+# Available Chrome builds on the stable channel
+./butler-sheet-icons.exe browser list-available
 
-# Available Firefox builds
-./butler-sheet-icons.exe browser list-available --browser firefox
+# Available Chrome builds on another channel
+./butler-sheet-icons.exe browser list-available --channel beta
 ```
 
 :::
@@ -361,9 +347,8 @@ Mount the folder, or leave the embedded browser alone.
 # Remove all
 ./butler-sheet-icons browser uninstall-all
 
-# Reinstall common browsers
-./butler-sheet-icons browser install --browser chrome
-./butler-sheet-icons browser install --browser firefox
+# Reinstall
+./butler-sheet-icons browser install
 
 # Verify
 ./butler-sheet-icons browser list-installed
@@ -373,9 +358,8 @@ Mount the folder, or leave the embedded browser alone.
 # Remove all
 ./butler-sheet-icons.exe browser uninstall-all
 
-# Reinstall common browsers
-./butler-sheet-icons.exe browser install --browser chrome
-./butler-sheet-icons.exe browser install --browser firefox
+# Reinstall
+./butler-sheet-icons.exe browser install
 
 # Verify
 ./butler-sheet-icons.exe browser list-installed

--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -56,7 +56,7 @@ If no system browser is configured, BSI looks in the Puppeteer cache directory (
 
 A cached browser is used when it matches **both** of these:
 
-- **Browser type** — the browser asked for with `--browser`. The thumbnail commands accept `chrome` only; the `browser` commands also accept `firefox`.
+- **Browser type** — the browser asked for with `--browser`. Every command accepts `chrome` only, and it is the default, so this matters only if you name it explicitly.
 - **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly that build ID is used. If a different version is cached, BSI treats it as no match and downloads the version you asked for. If `--browser-version` is `latest` (the default), any cached build of the requested browser type is accepted.
 
 When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.
@@ -93,7 +93,7 @@ The `browser` management commands are different — only some of them reach out 
 | ------------------------------------ | --------------- |
 | `browser list-installed`             | **No.** Reads the local Puppeteer cache only. |
 | `browser uninstall` / `uninstall-all` | **No.** Removes browsers from the local cache. |
-| `browser list-available`             | **Yes**, for Chrome. It asks Google's Chrome version history service which versions exist. (For Firefox the command only reports that `latest` is the sole supported version, and makes no network call.) |
+| `browser list-available`             | **Yes.** It asks Google's Chrome version history service which versions exist. |
 | `browser install`                    | **Yes**, always. BSI verifies that the requested build can actually be downloaded before installing it, so the command needs internet access even when that version is already in the cache. |
 
 On a machine with no internet access — an air-gapped server, or one behind a proxy that blocks outbound HTTPS — `browser list-available` reports:

--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -14,28 +14,31 @@ In addition to the cached browsers managed by BSI, you can also point BSI at a s
 
 ## Supported Browsers {#supported-browsers}
 
-Butler Sheet Icons manages two browsers, but they are not interchangeable:
+**Chrome is the only browser Butler Sheet Icons uses.** It is the only value `--browser` accepts, on every command that has the option, and full version control is available — including specific build numbers.
 
-- **Chrome**: the only browser that can render sheet thumbnails. Full version control available, including specific build numbers.
-- **Firefox**: can be installed, listed and removed with the `browser` commands, but **cannot be used to create thumbnails**.
+The reason is the rendering path. Thumbnails are produced by driving the browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/), with a list of startup switches only Chromium-based browsers understand. No other browser can be driven that way.
 
-::: warning Firefox is not available for thumbnails — BSI 4.0.0 or later
-`--browser firefox` is rejected by `qseow create-sheet-thumbnails` and `qscloud create-sheet-thumbnails`:
+::: warning Firefox is no longer accepted — BSI 5.0.0 or later
+Earlier versions let you install, list and remove a Firefox that no command could ever launch. `--browser firefox` is now rejected everywhere, by `browser install`, `browser uninstall` and `browser list-available` as well as by the thumbnail commands:
 
 ```
 error: option '--browser <browser>' argument 'firefox' is invalid. Allowed choices are chrome.
 ```
 
-The same applies when the value comes from an environment variable:
+Values coming from an environment variable are checked against the same list, so the run fails at start-up rather than part-way through:
 
 ```
-error: option '--browser <browser>' value 'firefox' from env 'BSI_QSEOW_CST_BROWSER' is invalid. Allowed choices are chrome.
+error: option '--browser <browser>' value 'firefox' from env 'BSI_BROWSER_LA_BROWSER' is invalid. Allowed choices are chrome.
 ```
 
-Firefox never actually worked for thumbnail creation — the rendering path drives the browser over the Chrome DevTools Protocol with a Chromium-only argument list — but earlier versions accepted the option and then failed later, in a way that was hard to interpret. It is now rejected up front.
+The variables affected are `BSI_BROWSER_I_BROWSER` (`browser install`), `BSI_BROWSER_UI_BROWSER` (`browser uninstall`), `BSI_BROWSER_LA_BROWSER` (`browser list-available`) and the `..._BROWSER` variables of the two thumbnail commands.
 
-`browser install`, `browser uninstall`, `browser uninstall-all` and `browser list-available` still accept `--browser firefox`.
+Firefox's release channels `nightly`, `devedition` and `esr` are no longer valid `--browser-version` values either, and neither are its channel-prefixed build ids such as `stable_153.0.3`.
+
+**If you have `--browser firefox` in a script**, remove the option. Chrome is the default, so nothing needs to replace it. A Firefox left in the browser cache by an earlier release is removed by [`browser uninstall-all`](/reference/browser#uninstall-all).
 :::
+
+`browser list-installed` and `browser uninstall-all` have no `--browser` option and are unaffected.
 
 ## Browser Cache Location
 
@@ -76,25 +79,19 @@ You can pre-install browsers into the BSI cache using the browser management com
 ::: code-group
 
 ```bash [Bash]
-# Install latest Chrome
+# Install the recommended Chrome build
 butler-sheet-icons browser install
 
-# Install specific Chrome version
-butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
-
-# Install Firefox
-butler-sheet-icons browser install --browser firefox
+# Install a specific Chrome build
+butler-sheet-icons browser install --browser-version 121.0.6167.85
 ```
 
 ```powershell [PowerShell]
-# Install latest Chrome
+# Install the recommended Chrome build
 butler-sheet-icons browser install
 
-# Install specific Chrome version
-butler-sheet-icons browser install --browser chrome --browser-version 121.0.6167.85
-
-# Install Firefox
-butler-sheet-icons browser install --browser firefox
+# Install a specific Chrome build
+butler-sheet-icons browser install --browser-version 121.0.6167.85
 ```
 
 :::
@@ -136,7 +133,7 @@ If you instead want to force BSI to use a _system_ browser (for example a centra
 | `recommended` | The build this version of Butler Sheet Icons was tested with. **This is the default.** | Fixed inside Butler Sheet Icons |
 | `stable` | The newest stable release of the browser. | Looked up online, every time the command runs |
 
-Both work for Chrome and Firefox, so you do not need to know what each vendor calls its channels.
+Both are keywords rather than build numbers, so you do not need to know what Google currently calls its builds.
 
 **`recommended` is the right choice for almost everyone.** It cannot get ahead of what Butler Sheet Icons is able to drive, and it changes only when you upgrade Butler Sheet Icons itself. That gives you two things:
 
@@ -147,7 +144,7 @@ Choose `stable` only if you specifically need the newest stable release — for 
 
 It also means a lookup on every run: on an offline or proxied machine that costs you connectivity you may not have. See [What `--browser-version` costs on an offline machine](/guide/concepts/browser-detection-and-environment-variables#what-browser-version-costs-on-an-offline-machine).
 
-Release **channels** are also accepted, and like `stable` they are resolved at run time: `beta`, `dev` and `canary` for Chrome; `beta`, `nightly`, `devedition` and `esr` for Firefox.
+Chrome's release **channels** are also accepted, and like `stable` they are resolved at run time: `beta`, `dev` and `canary`.
 
 ::: tip A browser is never bundled with Butler Sheet Icons
 Whichever value you use, the browser is downloaded once and then kept in the local cache, so the first run on a new server always needs internet access. The keywords differ only in *how the build id is decided* — which is what matters on a server that is offline afterwards. See [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables).
@@ -157,15 +154,13 @@ Whichever value you use, the browser is downloaded once and then kept in the loc
 
 You can pin an exact build. The format is checked before anything else happens, so a typo stops the run immediately with a message naming the accepted forms — it is never silently swapped for another build from the cache.
 
-For **Chrome**, three forms are accepted:
+Three forms are accepted:
 
 | Form | Example | Selects |
 | --- | --- | --- |
 | Milestone | `151` | The newest build of milestone 151 |
 | Build prefix | `151.0.7922` | The newest patch of that build |
 | Full build id | `151.0.7922.77` | Exactly that build |
-
-For **Firefox**, the build id must carry its channel prefix, for example `stable_153.0.3`. A bare version such as `152.0.1` is rejected: without the prefix it would be read as a nightly build, which is almost never what you want.
 
 To see what can be installed:
 
@@ -229,10 +224,6 @@ butler-sheet-icons.exe browser uninstall --browser chrome --browser-version <bui
 :::
 
 `browser uninstall` accepts an exact build id, or `recommended`. It deliberately does **not** accept `stable`, `latest` or a channel: those name whatever the vendor currently publishes, not a build on your machine, so they cannot safely identify something to delete. Uninstalling never needs internet access.
-
-### Firefox Versions
-
-Firefox is managed only by the `browser` commands — it cannot render thumbnails, so its version affects nothing about a thumbnail run. Firefox build ids are channel-prefixed, for example `stable_153.0.3`.
 
 ## Headless vs. Visible Browser {#headless-vs-visible-browser}
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -643,7 +643,7 @@ Creating thumbnails itself does not need internet access once a browser is avail
    butler-sheet-icons qscloud create-sheet-icons --browser chrome --browser-version 120.0.6099.109 ...
    ```
 
-   Firefox is not an alternative here — it cannot render thumbnails. See [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
+   Another browser is not an alternative here — Chrome is the only browser Butler Sheet Icons can use. See [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ### Browser Cache and Permissions
 
@@ -749,9 +749,6 @@ sudo apt-get install -y wget gnupg ca-certificates
 # For Chrome dependencies:
 sudo apt-get install -y libxss1 libappindicator1 libindicator7
 
-# For Firefox dependencies:
-sudo apt-get install -y libgtk-3-0 libdbus-glib-1-2
-
 # Check DISPLAY variable if running remotely
 echo $DISPLAY
 ```
@@ -764,17 +761,15 @@ Use these commands to diagnose browser-related issues:
 # Check current browser installation status
 butler-sheet-icons browser list-installed
 
-# Verify what browsers are available for download
-butler-sheet-icons browser list-available --browser chrome
-butler-sheet-icons browser list-available --browser firefox
+# Verify what Chrome builds are available for download
+butler-sheet-icons browser list-available
 
 # Test browser installation
-butler-sheet-icons browser install --browser chrome --loglevel debug
+butler-sheet-icons browser install --loglevel debug
 
-# Clean and reinstall all browsers
+# Clean and reinstall
 butler-sheet-icons browser uninstall-all
-butler-sheet-icons browser install --browser chrome
-butler-sheet-icons browser install --browser firefox
+butler-sheet-icons browser install
 
 # Test basic browser functionality with visible mode
 butler-sheet-icons qscloud create-sheet-icons \

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -6,7 +6,7 @@ For details on how BSI decides which browser to use at runtime, and how environm
 
 ## Overview
 
-BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The `browser` command manages both Chrome and Firefox across Windows, macOS, and Linux. Note that only Chrome can render sheet thumbnails — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
+BSI uses its own browser cache system and does not rely on browsers installed elsewhere on your system. This ensures consistency and allows for precise version control. The `browser` command manages Chrome across Windows, macOS, and Linux. Chrome is the only browser Butler Sheet Icons uses — see [Supported Browsers](/guide/concepts/browser-management#supported-browsers).
 
 ## Basic Usage
 
@@ -45,10 +45,11 @@ butler-sheet-icons browser list-installed [options]
 
 <!-- generated:cli-options browser list-installed -->
 
-| Option                            | Environment Variable       | Description                                                   | Default | Example            |
-| --------------------------------- | -------------------------- | ------------------------------------------------------------- | ------- | ------------------ |
-| `--log-level, --loglevel <level>` | `BSI_BROWSER_LI_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly) | `info`  | `--loglevel error` |
-| `-h, --help`                      | -                          | display help for command                                      | -       | `-h`               |
+| Option                            | Environment Variable       | Description                                                                                                                                                                                                                                            | Default | Example            |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_LI_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                          | `info`  | `--loglevel error` |
+| `--browser-cache-dir <directory>` | `BSI_BROWSER_CACHE_DIR`    | Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user's home directory otherwise. | -       | -                  |
+| `-h, --help`                      | -                          | display help for command                                                                                                                                                                                                                               | -       | `-h`               |
 
 <!-- /generated:cli-options -->
 
@@ -75,12 +76,12 @@ butler-sheet-icons browser list-available [options]
 
 <!-- generated:cli-options browser list-available -->
 
-| Option                            | Environment Variable       | Description                                                                                                                                                      | Default  | Example             |
-| --------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `--log-level, --loglevel <level>` | `BSI_BROWSER_LA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                    | `info`   | `--loglevel error`  |
-| `--browser <browser>`             | `BSI_BROWSER_LA_BROWSER`   | Browser to list available versions for (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser install" to install one of them. (choices: chrome, firefox) | `chrome` | `--browser firefox` |
-| `--channel <channel>`             | `BSI_BROWSER_LA_CHANNEL`   | Which of the browser's release channel versions should be listed? This option is only used for Chrome. (choices: stable, beta, dev, canary)                      | `stable` | `--channel beta`    |
-| `-h, --help`                      | -                          | display help for command                                                                                                                                         | -        | `-h`                |
+| Option                            | Environment Variable       | Description                                                                                                                                                         | Default  | Example            |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_LA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                       | `info`   | `--loglevel error` |
+| `--browser <browser>`             | `BSI_BROWSER_LA_BROWSER`   | Browser to list available versions for. Only "chrome" is supported. Use "butler-sheet-icons browser install" to install one of the listed builds. (choices: chrome) | `chrome` | `--browser chrome` |
+| `--channel <channel>`             | `BSI_BROWSER_LA_CHANNEL`   | Which of the browser's release channel versions should be listed? (choices: stable, beta, dev, canary)                                                              | `stable` | `--channel beta`   |
+| `-h, --help`                      | -                          | display help for command                                                                                                                                            | -        | `-h`               |
 
 <!-- /generated:cli-options -->
 
@@ -110,7 +111,7 @@ error: Butler Sheet Icons needs internet access for this command. If this machin
        available locally.
 ```
 
-Use `browser list-installed` instead to see what is already available locally. For Firefox the command makes no network call at all — it reports that only the latest version is supported and returns.
+Use `browser list-installed` instead to see what is already available locally — it reads the cache and never goes online.
 :::
 
 ### install
@@ -127,13 +128,14 @@ butler-sheet-icons browser install [options]
 
 <!-- generated:cli-options browser install -->
 
-| Option                            | Environment Variable            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Default       | Example             |
-| --------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------- |
-| `--log-level, --loglevel <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                                                                                                                                                                                                                    | `info`        | `--loglevel error`  |
-| `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome, firefox)                                                                                                                                                                                                                                                                                       | `chrome`      | `--browser firefox` |
-| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Browser build to install. Either a keyword - "recommended" for the build Butler Sheet Icons is tested with, "stable" for the newest stable release, or a release channel such as "beta" - or an exact version. For Chrome that is a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"); for Firefox a channel-prefixed build id ("stable_153.0.3"). Use "butler-sheet-icons browser list-available" to see what is available. | `recommended` | -                   |
-| `-i, --interactive`               | -                               | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                                                                                                                                                                                                                                   | -             | -                   |
-| `-h, --help`                      | -                               | display help for command                                                                                                                                                                                                                                                                                                                                                                                                                                         | -             | `-h`                |
+| Option                            | Environment Variable            | Description                                                                                                                                                                                                                                                                                                                                                                       | Default       | Example            |
+| --------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_I_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                                                                                                                                     | `info`        | `--loglevel error` |
+| `--browser <browser>`             | `BSI_BROWSER_I_BROWSER`         | Browser to install. Only "chrome" is supported. Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome)                                                                                                                                                                                                                  | `chrome`      | `--browser chrome` |
+| `--browser-version <version>`     | `BSI_BROWSER_I_BROWSER_VERSION` | Browser build to install. Either a keyword - "recommended" for the build Butler Sheet Icons is tested with, "stable" for the newest stable release, or a release channel such as "beta" - or an exact version: a milestone ("151"), a build prefix ("151.0.7922") or a full build id ("151.0.7922.77"). Use "butler-sheet-icons browser list-available" to see what is available. | `recommended` | -                  |
+| `--browser-cache-dir <directory>` | `BSI_BROWSER_CACHE_DIR`         | Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user's home directory otherwise.                                                                                                                            | -             | -                  |
+| `-i, --interactive`               | -                               | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                                                                                                                                                    | -             | -                  |
+| `-h, --help`                      | -                               | display help for command                                                                                                                                                                                                                                                                                                                                                          | -             | `-h`               |
 
 <!-- /generated:cli-options -->
 
@@ -149,23 +151,20 @@ PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser install
 2024-02-16T14:13:44.062Z info: Browser "chrome" version "121.0.6167.85" installed
 ```
 
-Install latest Firefox (macOS):
+Install a specific Chrome build (macOS):
 
 ```bash
-➜  butler-sheet-icons ./butler-sheet-icons browser install --browser firefox --browser-version latest
-2024-02-16T14:17:47.673Z info: App version: 3.2.3
-2024-02-16T14:17:47.976Z info: Resolved browser build id: "124.0a1" for browser "firefox" version "latest"
+➜  butler-sheet-icons ./butler-sheet-icons browser install --browser-version 151.0.7922.77
+2024-02-16T14:17:47.976Z info: Resolved browser build id: "151.0.7922.77" for browser "chrome" version "151.0.7922.77"
 2024-02-16T14:17:48.343Z info: Installing browser...
-2024-02-16T14:19:06.845Z info: Browser "firefox" version "124.0a1" installed
+2024-02-16T14:19:06.845Z info: Browser "chrome" version "151.0.7922.77" installed
 ```
 
 #### Browser Version Notes
 
-**Chrome:** a milestone (`151`), a build prefix (`151.0.7922`) or a full build id (`151.0.7922.77`). Some older builds may no longer be downloadable — use `list-available` to see what is currently offered.
+An exact build is a milestone (`151`), a build prefix (`151.0.7922`) or a full build id (`151.0.7922.77`). Some older builds may no longer be downloadable — use `list-available` to see what is currently offered.
 
-**Firefox:** a channel-prefixed build id such as `stable_153.0.3`. A bare version number is rejected, because it would be interpreted as a nightly build.
-
-Both also accept the keywords `recommended` and `stable`, and a release channel. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
+The keywords `recommended` and `stable` are also accepted, as are Chrome's release channels `beta`, `dev` and `canary`. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
 
 ::: warning Older Chrome Versions
 If you try to install an older Chrome version that's no longer available, you'll get a 404 error. The Chrome team periodically removes older versions from their download servers. Use a newer version instead.
@@ -193,13 +192,14 @@ butler-sheet-icons browser uninstall [options]
 
 <!-- generated:cli-options browser uninstall -->
 
-| Option                            | Environment Variable             | Description                                                                                                                                                                                                                                                              | Default      | Example             |
-| --------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ------------------- |
-| `--log-level, --loglevel <level>` | `BSI_BROWSER_UI_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                                            | `info`       | `--loglevel error`  |
-| `--browser <browser>`             | `BSI_BROWSER_UI_BROWSER`         | Browser to uninstall (e.g. "chrome" or "firefox"). Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome, firefox)                                                                                             | **Required** | `--browser firefox` |
-| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Browser build to uninstall: an exact build id (for Chrome e.g. "151.0.7922.77", for Firefox e.g. "stable_153.0.3"), or "recommended" for the build Butler Sheet Icons is tested with. Use "butler-sheet-icons browser list-installed" to see which builds are installed. | **Required** | -                   |
-| `-i, --interactive`               | -                                | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                                           | -            | -                   |
-| `-h, --help`                      | -                                | display help for command                                                                                                                                                                                                                                                 | -            | `-h`                |
+| Option                            | Environment Variable             | Description                                                                                                                                                                                                                                            | Default      | Example            |
+| --------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ------------------ |
+| `--log-level, --loglevel <level>` | `BSI_BROWSER_UI_LOG_LEVEL`       | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                          | `info`       | `--loglevel error` |
+| `--browser <browser>`             | `BSI_BROWSER_UI_BROWSER`         | Browser to uninstall. Only "chrome" is supported. Use "butler-sheet-icons browser list-installed" to see which browsers are currently installed. (choices: chrome)                                                                                     | **Required** | `--browser chrome` |
+| `--browser-version <version>`     | `BSI_BROWSER_UI_BROWSER_VERSION` | Browser build to uninstall: an exact build id (e.g. "151.0.7922.77"), or "recommended" for the build Butler Sheet Icons is tested with. Use "butler-sheet-icons browser list-installed" to see which builds are installed.                             | **Required** | -                  |
+| `--browser-cache-dir <directory>` | `BSI_BROWSER_CACHE_DIR`          | Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user's home directory otherwise. | -            | -                  |
+| `-i, --interactive`               | -                                | Answer questions instead of assembling a command line.<br>Options already supplied - here or through their BSI\_\* environment variables - are kept and not asked about again.                                                                         | -            | -                  |
+| `-h, --help`                      | -                                | display help for command                                                                                                                                                                                                                               | -            | `-h`               |
 
 <!-- /generated:cli-options -->
 
@@ -208,23 +208,20 @@ butler-sheet-icons browser uninstall [options]
 ```powershell
 # First, see what's installed
 PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser list-installed
-2024-02-16T14:24:20.096Z info: App version: 3.2.3
 2024-02-16T14:24:20.112Z info: Installed browsers:
 2024-02-16T14:24:20.112Z info:     chrome, build id=121.0.6167.85, platform=win64, path=C:\Users\goran\.cache\puppeteer\chrome\win64-121.0.6167.85
-2024-02-16T14:24:20.112Z info:     firefox, build id=124.0a1, platform=win64, path=C:\Users\goran\.cache\puppeteer\firefox\win64-124.0a1
+2024-02-16T14:24:20.112Z info:     chrome, build id=151.0.7922.77, platform=win64, path=C:\Users\goran\.cache\puppeteer\chrome\win64-151.0.7922.77
 
-# Uninstall specific Chrome version
+# Uninstall the older build
 PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser uninstall --browser-version 121.0.6167.85
-2024-02-16T14:26:39.018Z info: App version: 3.2.3
 2024-02-16T14:26:39.018Z info: Starting browser uninstallation
 2024-02-16T14:26:39.018Z info: Uninstalling browser: chrome, build id=121.0.6167.85, platform=win64, path=C:\Users\goran\.cache\puppeteer\chrome\win64-121.0.6167.85
 2024-02-16T14:26:39.096Z info: Browser "chrome", version "121.0.6167.85" uninstalled.
 
 # Verify uninstallation
 PS C:\tools\butler-sheet-icons> .\butler-sheet-icons.exe browser list-installed
-2024-02-16T14:26:44.597Z info: App version: 3.2.3
 2024-02-16T14:26:44.597Z info: Installed browsers:
-2024-02-16T14:26:44.613Z info:     firefox, build id=124.0a1, platform=win64, path=C:\Users\goran\.cache\puppeteer\firefox\win64-124.0a1
+2024-02-16T14:26:44.613Z info:     chrome, build id=151.0.7922.77, platform=win64, path=C:\Users\goran\.cache\puppeteer\chrome\win64-151.0.7922.77
 ```
 
 #### Browsers built for another platform
@@ -273,10 +270,11 @@ butler-sheet-icons browser uninstall-all [options]
 
 <!-- generated:cli-options browser uninstall-all -->
 
-| Option                            | Environment Variable       | Description                                                   | Default | Example            |
-| --------------------------------- | -------------------------- | ------------------------------------------------------------- | ------- | ------------------ |
-| `--log-level, --loglevel <level>` | `BS_BROWSER_UIA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly) | `info`  | `--loglevel error` |
-| `-h, --help`                      | -                          | display help for command                                      | -       | `-h`               |
+| Option                            | Environment Variable       | Description                                                                                                                                                                                                                                            | Default | Example            |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------ |
+| `--log-level, --loglevel <level>` | `BS_BROWSER_UIA_LOG_LEVEL` | Log level (choices: error, warn, info, verbose, debug, silly)                                                                                                                                                                                          | `info`  | `--loglevel error` |
+| `--browser-cache-dir <directory>` | `BSI_BROWSER_CACHE_DIR`    | Directory where Butler Sheet Icons keeps downloaded browsers. Defaults to a "browser-cache" folder next to the Butler Sheet Icons executable for standalone builds, and to the .cache/puppeteer folder in the current user's home directory otherwise. | -       | -                  |
+| `-h, --help`                      | -                          | display help for command                                                                                                                                                                                                                               | -       | `-h`               |
 
 <!-- /generated:cli-options -->
 
@@ -285,25 +283,22 @@ butler-sheet-icons browser uninstall-all [options]
 ```bash
 # Check current installations
 ➜  butler-sheet-icons ./butler-sheet-icons browser list-installed
-2024-02-16T14:27:20.425Z info: App version: 3.2.3
 2024-02-16T14:27:20.427Z info: Installed browsers:
 2024-02-16T14:27:20.428Z info:     chrome, build id=121.0.6167.85, platform=mac, path=/Users/goran/.cache/puppeteer/chrome/mac-121.0.6167.85
-2024-02-16T14:27:20.428Z info:     firefox, build id=124.0a1, platform=mac, path=/Users/goran/.cache/puppeteer/firefox/mac-124.0a1
+2024-02-16T14:27:20.428Z info:     chrome, build id=151.0.7922.77, platform=mac, path=/Users/goran/.cache/puppeteer/chrome/mac-151.0.7922.77
 
 # Remove all browsers
 ➜  butler-sheet-icons ./butler-sheet-icons browser uninstall-all
-2024-02-16T14:29:24.989Z info: App version: 3.2.3
 2024-02-16T14:29:24.990Z info: Starting uninstallation of all browsers
 2024-02-16T14:29:24.991Z info: Uninstalling 2 browsers:
 2024-02-16T14:29:24.992Z info:     Starting uninstallation of "chrome", build id "121.0.6167.85", platform "mac", path "/Users/goran/.cache/puppeteer/chrome/mac-121.0.6167.85"
-2024-02-16T14:29:25.880Z info:     Starting uninstallation of "firefox", build id "124.0a1", platform "mac", path "/Users/goran/.cache/puppeteer/firefox/mac-124.0a1"
-2024-02-16T14:29:26.214Z info: Removing any remaining files and directories in the browser cache directory
-2024-02-16T14:29:26.214Z info: Browser "chrome" (121.0.6167.85) uninstalled.
-2024-02-16T14:29:26.214Z info: Browser "firefox" (124.0a1) uninstalled.
+2024-02-16T14:29:25.880Z info: Browser "chrome" (121.0.6167.85) uninstalled.
+2024-02-16T14:29:25.881Z info:     Starting uninstallation of "chrome", build id "151.0.7922.77", platform "mac", path "/Users/goran/.cache/puppeteer/chrome/mac-151.0.7922.77"
+2024-02-16T14:29:26.213Z info: Browser "chrome" (151.0.7922.77) uninstalled.
+2024-02-16T14:29:26.214Z info: Removing any files the uninstall left behind in the browser cache
 
 # Verify all browsers removed
 ➜  butler-sheet-icons ./butler-sheet-icons browser list-installed
-2024-02-16T14:29:29.943Z info: App version: 3.2.3
 2024-02-16T14:29:29.944Z info: No browsers installed
 ```
 
@@ -311,14 +306,14 @@ butler-sheet-icons browser uninstall-all [options]
 
 ### Development Environment Setup
 
-1. **Install latest stable browsers:**
+1. **Install a browser:**
 
    ```bash
-   # Install latest Chrome
+   # Install the recommended Chrome build
    butler-sheet-icons browser install
 
-   # Install latest Firefox
-   butler-sheet-icons browser install --browser firefox
+   # Or the newest stable Chrome
+   butler-sheet-icons browser install --browser-version stable
    ```
 
 2. **Verify installation:**
@@ -355,11 +350,10 @@ If you're experiencing browser-related problems:
    butler-sheet-icons browser uninstall-all
    ```
 
-3. **Reinstall browsers:**
+3. **Reinstall the browser:**
 
    ```bash
-   butler-sheet-icons browser install --browser chrome
-   butler-sheet-icons browser install --browser firefox
+   butler-sheet-icons browser install
    ```
 
 ## Integration with Sheet Commands


### PR DESCRIPTION
BSI 5.0.0 stops accepting `--browser firefox` on `browser install`, `browser uninstall` and `browser list-available`. 4.0.0 had already removed it from the thumbnail commands, which left a browser that could be installed and removed but never launched — and five pages still telling readers to do exactly that.

Published from the `firefox-support-removed.md` draft in `docs/to-doc-site`.

## Approach

Removes the Firefox material rather than documenting its removal. The site is single-version, so it describes what the current release does. The one exception is a version callout on Browser Management, kept for administrators who have `--browser firefox` in a script and need to know what happened to it.

## Pages changed

| Page | What changed |
| --- | --- |
| `/guide/concepts/browser-management` | "Supported Browsers" rewritten around Chrome; new 5.0.0 callout listing the three environment variables and the rejected Firefox channels; "Firefox Versions" section deleted; two Firefox install examples deleted |
| `/reference/browser` | Option tables regenerated; Firefox install transcript replaced with a Chrome one; `list-installed` and `uninstall-all` transcripts reworked to show two Chrome builds |
| `/examples/browser-management` | "Install Firefox" section deleted; `list-available --browser firefox` examples replaced with `--channel`; reinstall examples simplified |
| `/guide/troubleshooting` | Firefox-as-alternative advice reworded; Firefox apt dependencies removed; diagnostic commands simplified |
| `/guide/concepts/browser-detection-and-environment-variables` | Browser-type matching rule corrected; `list-available` internet-access row simplified |

## Corrections against the implementation

The draft said none of the option tables on these pages are generated. That was true of `main` when it was written, but PR #73 landed on `next` in the meantime — `reference/browser.md` now carries 10 `generated:cli-options` blocks. Those rows were **regenerated**, not hand-edited, so every `--browser` row reads `(choices: chrome)` straight from the Commander definitions.

The regeneration also pulls in the `--browser-cache-dir` rows. They are accurate, but the prose explaining them arrives with the browser cache directory page, which is the next draft in the queue.

The `uninstall-all` transcript also had a stale log line (`Removing any remaining files and directories in the browser cache directory`); corrected to the current wording while it was being touched.

## Verification

- `npm run docs:build` passes
- `grep -ri firefox docs/` returns only the deliberate 5.0.0 callout
- `npm run docs:cli-tables -- <page> --check` reports all five tables current
- `#uninstall-all` and `#supported-browsers` anchors verified against the generated HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)