### PR TITLE
Describe the interactive sheet thumbnail wizards

### DIFF
--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -93,6 +93,95 @@ Those are shown, and labelled:
 They remain selectable on purpose. A browser you cannot run is still taking up disk space, and removing
 it is a perfectly reasonable thing to want.
 
+## Creating sheet thumbnails
+
+The two thumbnail commands are where this helps most. `qseow create-sheet-thumbnails` takes 36 options and `qscloud create-sheet-thumbnails` takes 25, so a first run has meant reading `--help`, assembling a long command line, and finding out only at the end that a certificate path or an API key was wrong.
+
+::: code-group
+
+```powershell [PowerShell]
+butler-sheet-icons.exe qseow create-sheet-thumbnails -i
+butler-sheet-icons.exe qscloud create-sheet-thumbnails -i
+```
+
+```bash [Bash]
+./butler-sheet-icons qseow create-sheet-thumbnails -i
+./butler-sheet-icons qscloud create-sheet-thumbnails -i
+```
+
+:::
+
+### It asks about a third of the options
+
+Most options have defaults that work against a stock installation, so you are not asked about them unless you say you want to be. Two questions gate the rest:
+
+```
+? Exclude or blur any sheets? (y/N)
+? Configure advanced options (ports, certificates, schema version, browser)? (y/N)
+```
+
+Answer no to both — the common case — and the count drops sharply:
+
+| Command | Options it declares | Questions asked |
+| --- | --- | --- |
+| `qseow create-sheet-thumbnails` | 36 | 14 |
+| `qscloud create-sheet-thumbnails` | 25 | 10 |
+
+Answer yes and the relevant block is asked in full. Nothing is hidden permanently — the defaults are simply not worth your time when they are already right. On Qlik Sense Cloud the second question reads *"Configure advanced options (schema version, timeouts, browser)?"*, since there are no ports or certificates to set.
+
+### Mistakes are reported where you make them
+
+This is the main practical difference from the command line.
+
+On **Qlik Sense Cloud**, the tenant is contacted as soon as you give the API key, so a bad key or a mistyped tenant URL is caught immediately and you are asked again:
+
+```
+? Qlik Sense cloud tenant URL … acme.eu.qlikcloud.com
+? API key … ********
+✖ Request failed with status code 401
+? API key …
+```
+
+On **QSEoW**, the certificate files are checked the moment you name them:
+
+```
+? Qlik Sense certificate file … ./cert/client.pem
+? Qlik Sense certificate key file … ./cert/wrong.pem
+✖ Certificate file(s) not found. Check --certfile and --certkeyfile.
+? Qlik Sense certificate key file …
+```
+
+The content library is checked the same way, when you choose it.
+
+Run the same thing as a plain command line and a bad certificate path is reported only after all 36 options have been typed — and a missing content library only after every screenshot has already been taken.
+
+### You choose apps from a list
+
+Rather than typing an app ID from memory:
+
+```
+? Which apps should be updated?
+❯ Choose from all apps on the server
+  Choose a tag, then apps carrying it
+  Type an app id
+
+? Which apps?
+❯ ◯ Finance dashboard  (id: a1b2c3d4-1111-2222-3333-444455556666)
+  ◯ Sales overview  (id: 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff)
+```
+
+On Qlik Sense Cloud the middle choice is a collection rather than a tag, and collections are shown with the number of items they hold, so an empty one is obvious before you pick it:
+
+```
+? Which collection?
+❯ Monthly reporting  (12 items)
+  Retired dashboards  (0 items)
+```
+
+**The app ID is always shown.** App names are not unique — two apps on the same server can share one — so the name alone would not tell you which is which. Showing the full ID also means you can copy it into [`--appid`](/reference/qseow#selecting-apps) later.
+
+Typing an ID directly is still offered, for when you already have it. And if the list cannot be fetched — a network problem, or an account without permission to read the app list — the wizard falls back to asking you to type the ID rather than stranding you.
+
 ## Starting from the command you were typing
 
 Going through the menu means starting over even when you already know which command you want and have

--- a/docs/reference/qscloud.md
+++ b/docs/reference/qscloud.md
@@ -10,6 +10,10 @@ Create thumbnail images for QS Cloud applications.
 butler-sheet-icons qscloud create-sheet-icons [options]
 ```
 
+::: tip Getting a first run working
+Add `-i` and Butler Sheet Icons asks for what it needs instead — 10 questions rather than 25 options, with the API key checked against your tenant as you give it, and the equivalent command line shown before anything runs. See [Interactive Mode](/guide/interactive-mode#creating-sheet-thumbnails).
+:::
+
 ### Options
 
 Four options have no default and must be supplied: `--tenanturl`, `--apikey`, `--logonuserid` and `--logonpwd`. Everything else has a working default.

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -10,6 +10,10 @@ Create thumbnail images for QSEoW applications.
 butler-sheet-icons qseow create-sheet-thumbnails [options]
 ```
 
+::: tip Getting a first run working
+Add `-i` and Butler Sheet Icons asks for what it needs instead — 14 questions rather than 36 options, with the certificate paths and the content library checked as you give them, and the equivalent command line shown before anything runs. See [Interactive Mode](/guide/interactive-mode#creating-sheet-thumbnails).
+:::
+
 ### Options
 
 Six options have no default and must be supplied: `--host`, `--apiuserdir`, `--apiuserid`, `--logonuserdir`, `--logonuserid` and `--logonpwd`. Everything else has a working default.


### PR DESCRIPTION
Published from the `creating-thumbnails-interactively.md` draft in `docs/to-doc-site`.

`qseow create-sheet-thumbnails` takes 36 options and its Qlik Sense Cloud twin 25, so a first run has meant reading `--help`, assembling a long command line, and finding out only at the end that a certificate path or an API key was wrong.

## Pages changed

| Page | What changed |
| --- | --- |
| `/guide/interactive-mode` | New **Creating sheet thumbnails** section, covering the two gate questions and what they cut the count to, answers checked at the prompt where they were given, and app selection from a list |
| `/reference/qseow`, `/reference/qscloud` | A "Getting a first run working" tip above the option table — someone looking at 36 rows is exactly who wants to know there is another way in |

## The question counts were measured, not copied

The draft says 36 → 14 and 25 → 10, but was internally inconsistent: its heading said *"It asks about ten questions, not thirty-six"*, mixing the two platforms' figures.

Rather than pick one, I ran each wizard's `refine` step over the real command definitions and counted the questions that survive with both gates declined:

```
qseow create-sheet-thumbnails   38 options declared (36 + -i + -h) → 14 questions
qscloud create-sheet-thumbnails 27 options declared (25 + -i + -h) → 10 questions
```

Both figures check out, and 14 matches what the QSEoW wizard asserts in its own comment. Worth noting for later: **nothing in the test suite locks these numbers**, so they should be re-measured rather than trusted if the option lists change.

The QSEoW figure also varies by one — the "choose a tag, then apps carrying it" path asks 15, since the tag is a question of its own. The page states the common path.

## Verified against the implementation

- Both gate messages verbatim, including that the Cloud wording differs (no ports or certificates)
- The three app-source choices, and the collection picker, from the wizards' `refine`
- `Certificate file(s) not found. Check --certfile and --certkeyfile.` verbatim
- `labelForApp` and `labelForCollection` — the id alongside the name, and the item count that makes an empty collection obvious
- The list-fetch fallback to typing an id, from the `fallback` spec on both pickers

## Verification

- `npm run docs:build` passes
- `#creating-sheet-thumbnails` and the three subsection anchors verified against the built HTML, along with `#selecting-apps` on the reference pages

Note: PR #78 merged to `next` without triggering a Cloudflare deployment, so merging this should publish both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)