### PR TITLE
Say what browser uninstall -i does with an empty cache

### DIFF
--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -94,6 +94,31 @@ Those are shown, and labelled:
 They remain selectable on purpose. A browser you cannot run is still taking up disk space, and removing
 it is a perfectly reasonable thing to want.
 
+### When there is nothing to uninstall
+
+On a machine with an empty browser cache, `browser uninstall -i` says so and stops without asking
+anything:
+
+```
+info: No browsers installed, so there is nothing to uninstall. Use "butler-sheet-icons browser install" to install one.
+```
+
+**The exit code is 0.** Nothing was asked for, so nothing failed — the same answer
+[`browser list-installed`](/reference/browser#list-installed) gives on that machine.
+
+The cache it looks in is the one the command itself would use, so this respects `--browser-cache-dir` and
+`BSI_BROWSER_CACHE_DIR`. A cache that exists but cannot be read is not treated as an empty one: you are
+still offered the chance to type a build id, which is how you recover.
+
+::: tip This is the interactive path only
+Running `browser uninstall` **without** `-i` is unchanged. Naming a build that is not in the cache still
+reports it and still exits **1**, which is what a scheduler or CI job sees:
+
+```
+info: Browser not found in cache: chrome build 151.0.7922.77. Use "butler-sheet-icons browser list-installed" to see what is installed.
+```
+:::
+
 ## Creating sheet thumbnails
 
 The two thumbnail commands are where this helps most. `qseow create-sheet-thumbnails` takes 36 options and `qscloud create-sheet-thumbnails` takes 25, so a first run has meant reading `--help`, assembling a long command line, and finding out only at the end that a certificate path or an API key was wrong.


### PR DESCRIPTION
Published from the `browser-uninstall-when-nothing-is-installed.md` draft in `docs/to-doc-site`.

On a machine with no browsers cached, `browser uninstall -i` used to ask which build to remove anyway — using `--browser-version`'s help text as the prompt. No answer to that question could succeed; every one ended in `Browser not found in cache`.

## Pages changed

| Page | What changed |
| --- | --- |
| `/guide/interactive-mode` | New **When there is nothing to uninstall** subsection under the browser wizard material |

## Two details the draft did not have

Both come from the precheck itself rather than the draft:

- **The cache it inspects is the one the command would use**, so `--browser-cache-dir` and `BSI_BROWSER_CACHE_DIR` are respected. That matters now that the location can be chosen — inspecting the default while the option names another would declare there is nothing to uninstall when there plainly is.
- **A cache that exists but cannot be read is deliberately not treated as empty.** You are still offered the chance to type a build id, which is how an operator recovers. "Not found" and "found but unusable" are different answers.

The exit code of **0** is stated plainly, because the surprising part is that a command doing nothing counts as success. The non-interactive path, which still exits **1**, is kept immediately next to it in a tip so a scheduler's behaviour is not confused with the wizard's.

## Not published from the draft

The draft's sample output carried an `info: App version: 4.1.0` line. Dropped rather than published — it dates the page, and published binaries have been mis-stamped before, so the number in a draft transcript is not necessarily what a reader sees.

The draft also re-explained the "Supplied, but asked about again..." banner. That is already covered under [One exception, and it says so](https://next.butler-sheet-icons-docs.pages.dev/guide/interactive-mode#one-exception-and-it-says-so) from an earlier draft, so it is not repeated.

## Verified against the implementation

- The stop message verbatim from `browser/uninstall.interactive.js`
- `Browser not found in cache: ...` verbatim from `browser/browser-uninstall.js`
- The precheck returns `{reason}` which is logged at `info` and returns success, so exit 0

## Verification

- `npm run docs:build` passes
- `#when-there-is-nothing-to-uninstall` and `#list-installed` verified against the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)