### PR TITLE
Show naming several apps in one run

### DIFF
--- a/docs/examples/qscloud.md
+++ b/docs/examples/qscloud.md
@@ -151,6 +151,78 @@ On macOS:
 
 :::
 
+## Several Named Apps in One Run
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions accepted exactly one `--appid`. Updating three named apps meant three runs, or putting
+them in a collection first.
+:::
+
+`--appid` takes as many app IDs as you like, separated by spaces or by commas:
+
+::: code-group
+
+```bash [macOS/Linux]
+./butler-sheet-icons qscloud create-sheet-thumbnails \
+  --appid 12345678-1234-1234-1234-123456789012,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff \
+  --tenanturl mytenant.eu.qlikcloud.com \
+  ...
+```
+
+```powershell [Windows PowerShell]
+.\butler-sheet-icons.exe qscloud create-sheet-thumbnails `
+  --appid 12345678-1234-1234-1234-123456789012,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff `
+  --tenanturl mytenant.eu.qlikcloud.com `
+  ...
+```
+
+:::
+
+The same applies to the environment variable, and to
+[`qscloud remove-sheet-icons`](/reference/qscloud#remove-sheet-icons):
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_QSCLOUD_CST_APP_ID = '12345678-1234-1234-1234-123456789012,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff'
+```
+
+```bash [Bash]
+export BSI_QSCLOUD_CST_APP_ID='12345678-1234-1234-1234-123456789012,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff'
+```
+
+:::
+
+A single `--appid <id>` behaves exactly as it always has, so existing scripts and scheduled tasks need no
+changes.
+
+### Combining with a collection
+
+`--appid` and `--collectionid` are **added together**, not chosen between — see
+[Selecting apps](/reference/qscloud#selecting-apps). This processes every app in the collection, **plus**
+the one named explicitly, and an app that is both is processed **once**:
+
+```bash
+./butler-sheet-icons qscloud create-sheet-thumbnails \
+  --collectionid 6547e7e0d0b3b0c1e4e0f1a2 \
+  --appid 12345678-1234-1234-1234-123456789012 \
+  ...
+```
+
+Run with `--loglevel debug` to see exactly which apps were selected, before any work starts:
+
+```
+debug: Will process these app IDs:
+debug: 12345678-1234-1234-1234-123456789012
+debug: 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+::: tip An empty variable means no apps, not one blank app
+A variable that is set but empty — a bare `BSI_QSCLOUD_CST_APP_ID=` line in a Docker environment file —
+counts as no app being named. If nothing else selects any apps, the run reports `No apps to process` and
+exits 1 rather than failing on a blank ID.
+:::
+
 ## Collection-Based Bulk Update
 
 Update all apps in a collection, excluding specific sheets:

--- a/docs/examples/qseow.md
+++ b/docs/examples/qseow.md
@@ -48,6 +48,87 @@ And here's the same operation on Windows:
 
 ![Windows Execution Example](/images/windows-execution.png "Butler Sheet Icons executing on Windows for QSEoW")
 
+## Several Named Apps in One Run
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions accepted exactly one `--appid`. Updating three named apps meant three runs, or tagging
+them in Qlik Sense first.
+:::
+
+`--appid` takes as many app IDs as you like, separated by spaces:
+
+::: code-group
+
+```bash [macOS/Linux]
+./butler-sheet-icons qseow create-sheet-thumbnails \
+  --appid a3e0f5d2-000a-464f-998d-33d333b175d7 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff \
+  --host qlik-server.company.com \
+  ...
+```
+
+```powershell [Windows PowerShell]
+.\butler-sheet-icons.exe qseow create-sheet-thumbnails `
+  --appid a3e0f5d2-000a-464f-998d-33d333b175d7 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff `
+  --host qlik-server.company.com `
+  ...
+```
+
+:::
+
+Commas work too, which is usually easier to read and easier to paste:
+
+```
+--appid a3e0f5d2-000a-464f-998d-33d333b175d7,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+Both forms work in the environment variable as well:
+
+::: code-group
+
+```powershell [PowerShell]
+$env:BSI_QSEOW_CST_APP_ID = 'a3e0f5d2-000a-464f-998d-33d333b175d7,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff'
+```
+
+```bash [Bash]
+export BSI_QSEOW_CST_APP_ID='a3e0f5d2-000a-464f-998d-33d333b175d7,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff'
+```
+
+:::
+
+A single `--appid <id>` behaves exactly as it always has, so existing scripts, scheduled tasks and
+container runs need no changes.
+
+### Combining with a tag
+
+`--appid` and `--qliksensetag` are **added together**, not chosen between — see
+[Selecting apps](/reference/qseow#selecting-apps). This processes every app carrying the tag, **plus** the
+one named explicitly:
+
+```bash
+./butler-sheet-icons qseow create-sheet-thumbnails \
+  --qliksensetag "Butler Sheet Icons" \
+  --appid a3e0f5d2-000a-464f-998d-33d333b175d7 \
+  ...
+```
+
+An app that is both named and tagged is still processed **once**.
+
+### Checking which apps were selected
+
+Run with `--loglevel debug` and Butler Sheet Icons lists them before any work starts:
+
+```
+debug: Will process these app IDs:
+debug: a3e0f5d2-000a-464f-998d-33d333b175d7
+debug: 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff
+```
+
+::: tip An empty variable means no apps, not one blank app
+A variable that is set but empty — a bare `BSI_QSEOW_CST_APP_ID=` line in a systemd unit file or a Docker
+environment file — counts as no app being named. If nothing else selects any apps, the run reports
+`No apps to process` and exits 1 rather than failing on a blank ID.
+:::
+
 ## Tag-Based Bulk Update
 
 Update all apps with a specific tag, applying advanced filtering:

--- a/docs/guide/concepts/environment-variables.md
+++ b/docs/guide/concepts/environment-variables.md
@@ -117,6 +117,29 @@ butler-sheet-icons qscloud create-sheet-thumbnails
 
 :::
 
+## Variables holding more than one value
+
+Two kinds of option take a list, and they behave differently in an environment variable.
+
+**App IDs take a comma-separated list.** `BSI_QSEOW_CST_APP_ID` and `BSI_QSCLOUD_CST_APP_ID` each accept
+several, which is how you name a fixed set of apps without tagging them in Qlik Sense first:
+
+```bash
+export BSI_QSEOW_CST_APP_ID='a3e0f5d2-000a-464f-998d-33d333b175d7,9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff'
+```
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions accepted exactly one app ID.
+:::
+
+**Sheet numbers take exactly one.** `BSI_QSEOW_CST_EXCLUDE_SHEET_NUMBER` and the blur equivalent hold a
+single number, and a value containing more than one is rejected at startup. To select several sheets,
+pass the option on the command line instead — see
+[Listing several sheet numbers](/guide/concepts/sheet-exclusion#listing-several-sheet-numbers).
+
+**A variable that is set but empty counts as unset.** A bare `BSI_QSEOW_CST_APP_ID=` line in a systemd
+unit file or a Docker environment file means no app was named, rather than one app with a blank ID.
+
 ## Behavior and security
 
 - With environment variables set, you can run BSI with minimal parameters.


### PR DESCRIPTION
Published from the `several-apps-in-one-run.md` draft in `docs/to-doc-site`.

`--appid` used to accept exactly one app: three named apps meant three runs, or tagging them in Qlik Sense first. It now takes as many as you like, on both thumbnail commands and on `qscloud remove-sheet-icons`.

## Scope was smaller than the draft assumed

The reference pages already carry most of this. Their option tables are generated, so the corrected `--appid` description — *"Several ids can be given, separated by spaces or commas. Combines with --qliksensetag rather than replacing it"* — arrived with PR #76, along with the `Selecting apps` sections on both pages.

What was missing was the worked examples an administrator actually copies.

## Pages changed

| Page | What changed |
| --- | --- |
| `/examples/qseow` | New **Several Named Apps in One Run** section — space and comma forms, the environment variable, combining with a tag, and checking the selection with `--loglevel debug` |
| `/examples/qscloud` | The same, for collections, and noting `remove-sheet-icons` takes the list too |
| `/guide/concepts/environment-variables` | New **Variables holding more than one value** section |

Both example sections sit between "Basic Single App Update" and the bulk-by-tag/collection case, which is where someone with a handful of named apps is looking.

## The environment variables section

Two list-valued variables behave in opposite ways, and stating them together is more useful than either alone:

- `BSI_*_APP_ID` takes a **comma-separated list**
- `BSI_*_EXCLUDE_SHEET_NUMBER` and the blur equivalent take **exactly one**, and reject more at startup
- A variable that is **set but empty counts as unset** — a bare `BSI_QSEOW_CST_APP_ID=` line means no app was named, not one app with a blank ID

The last point is the draft's, and it is the one most likely to bite someone templating a systemd unit or a Docker env file.

## Verified against the implementation

- `collectAppIds` in `src/lib/commands/helpers.js` — splits on comma, trims, drops empties, and is variadic so spaces work too
- Its three call sites: `qseow create-sheet-thumbnails`, `qscloud create-sheet-thumbnails`, `qscloud remove-sheet-icons`
- Deduplication is `[...new Set(appIds)]` in `runOverApps`, so an app both named and tagged is processed once
- `Will process these app IDs:` and the per-id lines, at `debug`, verbatim from the same function
- An empty selection logs `No apps to process.` and returns false, so the run exits 1

## Verification

- `npm run docs:build` passes
- Every anchor referenced (`#selecting-apps` on both reference pages, `#remove-sheet-icons`, `#listing-several-sheet-numbers`, `#run-failures-and-exit-codes`) verified against the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)