### PR TITLE
Record QSEoW 2026-May support and correct the version guidance

### DIFF
--- a/docs/guide/configuration/qseow.md
+++ b/docs/guide/configuration/qseow.md
@@ -144,16 +144,16 @@ For development/testing environments:
 
 ## QSEoW Version Specification
 
-**Critical**: You must specify your QSEoW version for compatibility:
+`--sense-version` tells Butler Sheet Icons which Qlik Sense hub layout to expect. It defaults to the most recent supported release, so set it when your server is older:
 
 ```bash
---sense-version 2024-Nov          # Use the version used in your Qlik Sense environment
+--sense-version 2025-Nov          # Use the version used in your Qlik Sense environment
 ```
 
 For a list of supported QSEoW versions and the exact values to use with `--sense-version`, see [Supported Versions → QSEoW](/reference/supported-versions#qlik-sense-enterprise-on-windows-qseow).
 
 ::: warning Version Compatibility
-Using the wrong version parameter may cause login or navigation failures. Always specify the correct version for your QSEoW installation.
+Setting this explicitly is worth doing on a server you do not upgrade often, so a change to the default in a later Butler Sheet Icons release cannot move underneath you. See [What the version is used for](/reference/supported-versions#what-the-version-is-used-for) for what it actually affects.
 :::
 
 ::: tip Command alias

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -286,13 +286,11 @@ An app is saved once, after all of its sheets have been dealt with. If the run f
 
 ```bash
 # Check your QSEoW version in QMC → About
-# Use the correct version parameter
---sense-version 2024-May    # Use exact version
-
-# Available versions:
-# 2024-Nov, 2024-May, 2023-Nov, 2023-Aug, 2023-May,
-# 2023-Feb, 2022-Nov, pre-2022-Nov
+# Then set the matching value
+--sense-version 2025-Nov
 ```
+
+The accepted values are listed in the [`--sense-version` row of the QSEoW reference](/reference/qseow#options), which is generated from the command definitions and therefore always current. A wrong value is rejected at startup rather than causing a confusing failure later.
 
 ### Content Library Issues (QSEoW)
 

--- a/docs/reference/supported-versions.md
+++ b/docs/reference/supported-versions.md
@@ -6,14 +6,22 @@ Butler Sheet Icons is regularly tested against various versions of Qlik Sense to
 
 Butler Sheet Icons supports multiple QSEoW versions using the `--sense-version` parameter to handle version-specific differences in the web interface.
 
+::: tip Two different questions
+**Which values are accepted** is decided by the code, and the complete list is in the `--sense-version` row of the [QSEoW command reference](/reference/qseow#options) — that table is generated from the command definitions, so it cannot fall behind.
+
+**Which versions have been tested** is what the table below records. A value can be accepted without having a test date here.
+:::
+
 ### Currently Supported Versions
 
 | QSEoW Version    | BSI Version | Last Tested | Command Parameter              | Status            |
 | ---------------- | ----------- | ----------- | ------------------------------ | ----------------- |
+| 2026-May IR      | 5.0.0       | 2026-Aug-11 | `--sense-version 2026-May`     | ✅ Supported      |
 | 2025-Nov IR      | 3.9.0       | 2025-Nov-24 | `--sense-version 2025-Nov`     | ✅ Supported      |
 | 2025-May IR      | 3.9.0       | 2025-Nov-22 | `--sense-version 2025-May`     | ✅ Supported      |
 | 2024-Nov IR      | 3.8.0       | 2025-Jan-6  | `--sense-version 2024-Nov`     | ✅ Supported      |
 | 2024-May IR      | 3.8.0       | 2024-Dec-6  | `--sense-version 2024-May`     | ✅ Supported      |
+| 2024-Feb IR      | —           | —           | `--sense-version 2024-Feb`     | ✅ Accepted       |
 | 2023-Nov patch 3 | 3.6.4       | 2024-Nov-6  | `--sense-version 2023-Nov`     | ✅ Supported      |
 | 2023-Aug patch 3 | 3.6.0       | 2024-Jan-4  | `--sense-version 2023-Aug`     | ✅ Supported      |
 | 2023-May patch 6 | 3.5.0       | 2023-Oct-6  | `--sense-version 2023-May`     | ✅ Supported      |
@@ -24,19 +32,40 @@ Butler Sheet Icons supports multiple QSEoW versions using the `--sense-version` 
 
 ### Version Selection
 
-The `--sense-version` parameter is **mandatory** for QSEoW installations. Choose the parameter that matches your QSEoW version:
+`--sense-version` defaults to **`2026-May`**, so a run against a current server needs no version option at all. Set it explicitly when your server is older:
 
 ```bash
-# For May 2024 release
+# Against a 2025-Nov server
 butler-sheet-icons qseow create-sheet-thumbnails \
-  --sense-version 2024-May \
+  --sense-version 2025-Nov \
   # ... other options
 
-# For November 2023 release
+# Against a 2023-Nov server
 butler-sheet-icons qseow create-sheet-thumbnails \
   --sense-version 2023-Nov \
   # ... other options
 ```
+
+The same value can be given through `BSI_QSEOW_CST_SENSE_VERSION`, which is usually the better choice for a scheduled task.
+
+::: warning The default changed in BSI 5.0.0
+Earlier versions defaulted to an older release. If you relied on the default rather than setting `--sense-version` explicitly, check that it still matches your server — and set it explicitly if it does not, which is worth doing anyway on a server you do not upgrade often.
+:::
+
+### What the version is used for
+
+`--sense-version` tells Butler Sheet Icons which Qlik Sense hub layout to expect. In practice it now affects one thing: **finding the logout control in the hub user menu**, and only as a fallback.
+
+Logging out normally goes through the Qlik Proxy Service session, which does not depend on the hub's page structure at all — so a changed menu, or a user with different permissions, is far less likely to affect a run than it once was. The hub user menu is used only if the proxy request is not accepted, and even then the stable logout hook is tried before the version-specific selector.
+
+A failed logout does not discard thumbnails that were already created. The browser and engine sessions are still closed, processing continues, and the log says what happened:
+
+```
+error: QSEOW: Could not log out of Qlik Sense - both the proxy session API and the hub's user menu failed.
+error: QSEOW: Thumbnail generation completed, but logout was skipped. Processing will continue; if upload and sheet updates complete, only logout will have failed.
+```
+
+If you see that, the log also names the `--sense-version` you ran with and asks you to report it. Include the Qlik Sense release and service-release information — that is what identifies the layout Butler Sheet Icons needs to learn.
 
 ### Finding Your QSEoW Version
 


### PR DESCRIPTION
Published from the `qseow-2026-may-support.md` draft in `docs/to-doc-site`.

2026-May is supported and is now the `--sense-version` default. Three places on the site said otherwise.

## Pages changed

| Page | What changed |
| --- | --- |
| `/reference/supported-versions` | 2026-May added, and 2024-Feb, which has been accepted since 2024 and was never listed. The "mandatory" claim replaced with what the default is and when to override it. New **What the version is used for** section |
| `/guide/configuration/qseow` | *"Critical: You must specify your QSEoW version"* — no longer true |
| `/guide/troubleshooting` | A hardcoded list of accepted values, three releases stale, replaced with a pointer to the generated table |

## Corrections against the implementation

- **`--sense-version` is not mandatory.** It is declared `.choices(QSEOW_SENSE_VERSIONS).default(DEFAULT_QSEOW_SENSE_VERSION).env(...)` with no `makeOptionMandatory()`. The page had called it mandatory, which is wrong twice over — it is optional, and it has a working default.
- **The default is `2026-May`**, from `DEFAULT_QSEOW_SENSE_VERSION` in `qseow-selectors.js`.
- **Two versions were missing from the table**: 2026-May, and 2024-Feb — accepted since commit `dc932a3` in March 2024, never documented.
- **The troubleshooting list of accepted values** was missing 2024-Feb, 2025-May, 2025-Nov and 2026-May. Removed rather than extended: it is a hand-typed copy of a generated table, which is the drift the generator exists to prevent.

## A structural fix worth noting

The Supported Versions table conflates two questions. **Which values are accepted** is decided by the code and is answered by the generated `--sense-version` row on `/reference/qseow`. **Which versions have been tested** is what the table records, and is hand-maintained.

The page now says so explicitly. That is what lets 2024-Feb be listed honestly with em-dashes in the BSI Version and Last Tested columns, rather than either inventing test data or leaving an accepted value undocumented.

2026-May's row uses BSI 5.0.0 and 2026-Aug-11 — the date of `a155b73`, which added the release and states it was verified against a real server for #883.

## What the version is used for

Worth documenting because the answer has narrowed. Logout now goes through the Qlik Proxy Service session, which does not depend on the hub's page structure; the hub user menu is a fallback, and even then a stable `tid="globalmenu-logout"` hook is tried before the version-specific selector. A failed logout does not discard thumbnails already created — the sessions are still closed and processing continues.

Both quoted error lines are verbatim from `src/lib/qseow/qseow-logout.js`.

## Verification

- `npm run docs:build` passes
- `#what-the-version-is-used-for`, `#options` on the QSEoW reference, and `#qlik-sense-enterprise-on-windows-qseow` verified against the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)