### PR TITLE
Record 2026-May SR2 as the tested QSEoW release

### DIFF
--- a/docs/reference/supported-versions.md
+++ b/docs/reference/supported-versions.md
@@ -16,7 +16,7 @@ Butler Sheet Icons supports multiple QSEoW versions using the `--sense-version` 
 
 | QSEoW Version    | BSI Version | Last Tested | Command Parameter              | Status            |
 | ---------------- | ----------- | ----------- | ------------------------------ | ----------------- |
-| 2026-May IR      | 5.0.0       | 2026-Aug-11 | `--sense-version 2026-May`     | ✅ Supported      |
+| 2026-May SR2     | 5.0.0       | 2026-Aug-11 | `--sense-version 2026-May`     | ✅ Supported      |
 | 2025-Nov IR      | 3.9.0       | 2025-Nov-24 | `--sense-version 2025-Nov`     | ✅ Supported      |
 | 2025-May IR      | 3.9.0       | 2025-Nov-22 | `--sense-version 2025-May`     | ✅ Supported      |
 | 2024-Nov IR      | 3.8.0       | 2025-Jan-6  | `--sense-version 2024-Nov`     | ✅ Supported      |


### PR DESCRIPTION
Follow-up to [#83](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/83).

That PR added a `2026-May IR` row to the Supported Versions table. "IR" was my assumption from the pattern of the rows around it. Butler Sheet Icons is developed and tested against a **2026-May SR2** server, so that is what the row should say — the column records the release actually tested, not the release family.

| | |
| --- | --- |
| Was | `2026-May IR` |
| Now | `2026-May SR2` |

Nothing else changes: the `--sense-version 2026-May` value, the BSI version and the last-tested date are unaffected.

## Verification

- `npm run docs:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)