### PR TITLE
Name the platform macOS, not Macintosh

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -326,8 +326,8 @@ in which a browser states what it is and which operating system it runs on. The 
 ```mermaid
 flowchart TD
     Start([Browser requests a sheet]) --> UA{"User-Agent matches the proxy's<br/>Windows authentication pattern?"}
-    UA -->|"No — Macintosh, X11"| Forms["/internal_forms_authentication/<br/>the login page"]
-    UA -->|"Yes — Windows NT"| NTLM["/internal_windows_authentication<br/>NTLM"]
+    UA -->|"No — macOS, Linux"| Forms["/internal_forms_authentication/<br/>the login page"]
+    UA -->|"Yes — Windows"| NTLM["/internal_windows_authentication<br/>NTLM"]
     Forms --> OK([BSI types the credentials and works])
     NTLM --> Fail([ERR_INVALID_AUTH_CREDENTIALS])
 ```


### PR DESCRIPTION
Follow-up to [#85](https://github.com/ptarmiganlabs/butler-sheet-icons-docs/pull/85).

The User-Agent decision diagram labelled its branches `"No — Macintosh, X11"` and `"Yes — Windows NT"`. Those are User-Agent substrings used as if they were platform names, and nobody calls the platform Macintosh.

| | |
| --- | --- |
| Was | `No — Macintosh, X11` / `Yes — Windows NT` |
| Now | `No — macOS, Linux` / `Yes — Windows` |

The branches are what a reader is deciding between, so they should name platforms.

**The table below the diagram is unchanged and stays verbatim.** Its column is headed *"User-Agent contains"*, and `Macintosh; Intel Mac OS X` is literally what the header contains — it is also what the `curl` check on the same page tells you to send, so changing it would break the explanation.

## Verification

- `npm run docs:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)