### PR TITLE
Explain an unreadable reply from Qlik Sense Cloud

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -168,6 +168,68 @@ Every image is attempted before the run stops, so one failure does not hide the 
 
 If earlier runs left apps showing broken sheet icons, re-running `create-sheet-thumbnails` against those apps repairs them, once the upload problem itself is resolved. To clear the icons instead of regenerating them, use `qscloud remove-sheet-icons` — note this exists only for Qlik Sense Cloud.
 
+### `Qlik Sense Cloud returned an unusable response` {#cloud-unusable-response}
+
+Butler Sheet Icons asked your tenant for a list — your collections, the apps in a collection, or the apps on the tenant — and what came back was not a list.
+
+```
+Qlik Sense Cloud returned an unusable response for "collections": expected a list, got string
+```
+
+The last word is what arrived instead: `string` for an HTML page, `object` for an error document. If the tenant answered successfully but sent nothing at all, you get this instead:
+
+```
+Qlik Sense Cloud returned status 200 and an empty body for "collections", expected a list
+```
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions failed with `TypeError: allCollections.map is not a function`, naming a variable inside Butler Sheet Icons. It did not say which request failed, which tenant answered, or what the tenant actually sent.
+:::
+
+The quoted part is the request that failed, which tells you what to look at:
+
+| Request | What Butler Sheet Icons was asking for |
+| ------------------------ | -------------------------------------- |
+| `collections` | The collections on your tenant |
+| `collections/<id>/items` | The contents of one collection |
+| `items?resourceType=app` | Every app on the tenant |
+
+**What to check:**
+
+This message means the request **succeeded** — Qlik Cloud, or something standing in for it, answered with a normal success code — but what came back was not a list of anything. That narrows the cause considerably:
+
+- **Something is answering instead of your tenant.** A proxy, gateway or corporate network that intercepts outbound traffic will happily return its own page with a 200. `got string` almost always means HTML arrived where JSON was expected. Try the same URL from the machine running Butler Sheet Icons and look at what comes back.
+- **The tenant URL points somewhere that is not a Qlik Cloud tenant.** A typo in `--tenanturl` that still resolves to a real web server produces exactly this.
+- **An empty body** usually means a gateway timed out and closed the response without content.
+
+::: tip A rejected API key does **not** produce this message
+Expired keys, missing scopes and wrong tenant names return proper HTTP error codes, and those are reported separately as a failed request naming the status. If you are chasing a permissions problem, that is the message to look for — not this one. See [QS Cloud Authentication Problems](#qs-cloud-authentication-problems).
+:::
+
+**An empty result is still an empty result.** A tenant with no collections, or a collection with no apps, is a normal answer and is treated as one. Only a reply Butler Sheet Icons cannot read is reported as a failure. That matters for scheduled jobs: a broken tenant can no longer look like a successful run that happened to have nothing to do.
+
+**On Qlik Sense Enterprise on Windows** the equivalent message names the QRS instead, and means the same thing — something answered where the repository service was expected:
+
+```
+QRS returned an unusable response for "app/full": expected a list, got string
+```
+
+The quoted part is the QRS path that was asked for, in the same way as the Cloud paths above.
+
+### `Skipping collection item … as it claims to be an app but carries no app id`
+
+An entry in an otherwise valid list claims to be an app but carries no app id. It is skipped with a warning and the other apps in the list are processed as normal:
+
+```
+warn: Skipping collection item 61b1c8e5f9d4a70001d4e5f6 as it claims to be an app but carries no app id
+```
+
+::: warning Requires BSI 5.0.0 or later
+Previously such an entry either stopped the run outright or, worse, was carried forward as an app with no id and reported later as a failure that named nothing.
+:::
+
+**What to do:** that one app is missing from the run. The warning names the item so you can find it in the tenant. `warn: Skipping tenant item …` is the same thing when the apps were listed from the tenant rather than from a collection.
+
 ### `TypeError: Cannot read properties of undefined (reading 'rank')`
 
 A single sheet missing its layout data caused the **whole app** to be abandoned before any thumbnail was created or removed. Every other sheet in that app was left untouched.
@@ -209,6 +271,10 @@ An app is saved once, after all of its sheets have been dealt with. If the run f
 - Login failures
 - "Invalid credentials" errors
 - Stuck on login page
+
+::: tip Not every tenant problem is a credentials problem
+`Qlik Sense Cloud returned an unusable response` means the request **succeeded** and returned something that was not a list — typically a proxy or gateway answering instead of your tenant. A rejected API key produces an HTTP error code instead. See [that message](#cloud-unusable-response).
+:::
 
 **Solutions:**
 


### PR DESCRIPTION
Published from the `unreadable-replies-from-qlik-sense-cloud.md` draft in `docs/to-doc-site`.

Asking the tenant for a list and getting something else used to fail with `TypeError: allCollections.map is not a function` — a variable name from inside Butler Sheet Icons, saying nothing about which request failed, which tenant answered, or what arrived instead.

## Pages changed

| Page | What changed |
| --- | --- |
| `/guide/troubleshooting` | New **`Qlik Sense Cloud returned an unusable response`** entry, and a separate entry for the skipped-item warning, both under Run Failures and Exit Codes |
| `/guide/troubleshooting` → QS Cloud Authentication Problems | A tip distinguishing this from a credentials problem |

## Placement

With the other **message-keyed** entries under Run Failures, beside `Connection test to tenant …` and `TypeError: … (reading 'rank')`, rather than under authentication.

The draft suggested the authentication section, but the distinguishing fact about this message is that the request **succeeded** — a rejected API key returns an HTTP error code and takes a different path entirely. Axios rejects on 4xx/5xx with no `validateStatus` override, so those never reach this check. The page says so plainly, because an administrator chasing a permissions problem should not stop here. The authentication section links across instead.

The skipped-item warning gets its own entry rather than a footnote: an app that should have been in the run is now missing and the run still reports success, so nothing else would tell you.

## Beyond the draft

The **QSEoW counterpart** is now documented. The same guard exists over QRS responses and its message was not on the site anywhere, although the fix it came from is described in the "Fixed in 4.1.0" section without quoting anything searchable.

I first wrote that example with a full URL. `apiUrl` is a QRS **path** — `app/full`, `app/full?filter=…` — so the example was corrected against the call sites rather than left as a plausible-looking guess.

## Verified against the implementation

- Both Cloud messages verbatim from `saas-response.js`, including that `shape` is `typeof` — hence `got string` for HTML, `got object` for an error document
- All three API paths from the `saasGetList` call sites: `collections`, `collections/<id>/items`, `items?resourceType=app`
- The skip warning verbatim, and that `source` is `collection` or `tenant` — so both wordings are given
- An empty list returns `[]` rather than throwing, so an empty tenant is still a normal answer

## Verification

- `npm run docs:build` passes
- `#cloud-unusable-response` and `#qs-cloud-authentication-problems` verified against the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)