### PR TITLE
Explain that a closed output pipe is not a crash

### DIFF
--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -223,6 +223,46 @@ rm /tmp/butler-sheet-icons-crash-*
 
 Adjust the path if `BSI_CRASH_DUMP_DIR` points somewhere else.
 
+## A closed output pipe is not a crash {#a-closed-output-pipe-is-not-a-crash}
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions wrote a crash dump when the command's output pipe closed.
+:::
+
+Looking at the first few lines of a long list is an everyday thing to do:
+
+```bash
+butler-sheet-icons browser list-available --channel stable | head -12
+```
+
+Until 5.0.0 that left a `.json` and a `.txt` crash report behind, in whatever directory you happened to be standing in, saying Butler Sheet Icons had crashed:
+
+```
+=== CRASH INFO ===
+Error Type: Error
+Source: uncaughtException
+Exit Code: 1
+
+=== ERROR MESSAGE ===
+write EPIPE
+```
+
+Nothing had gone wrong. `head` stops reading once it has the twelve lines you asked for, and the next line Butler Sheet Icons tried to print had nowhere to go. That is what `write EPIPE` means: *the thing reading my output has gone away*. The same happened with a pager you quit before the end, with `grep -m1`, and with any other command that stops reading early.
+
+A closed output pipe is now treated as an ordinary end to the run. **No crash dump is written, and nothing is printed about it** — the stream any message would go to is the one that just died. The command above leaves your working directory exactly as it found it, and the output itself is unchanged: you still get the same twelve lines.
+
+The run ends with exit code **141** rather than `0`; see [Exit code 141](/reference/commands#exit-code-141) for why, and who it affects.
+
+### Real failures are unaffected
+
+Worth being clear about, because the two can happen together:
+
+- A genuine error still writes one `.json` and one `.txt` crash report and exits with code **1**, with its `FATAL:` line in the log.
+- That remains true **even when the output pipe has already closed**. If a run crashes for a real reason while you happen to be piping it through `head`, you still get the crash report you need.
+- A failure to write output for any *other* reason — a full disk, a permission problem — is still a genuine error and still produces a crash report.
+
+The `BSI_CRASH_DUMP_*` variables are unchanged, and so is the one-dump-per-run behaviour above.
+
 ## Related
 
 - [Secret redaction in logs](/reference/log-redaction) — what is redacted from log output, and how that differs from the redaction applied to crash dumps.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -168,6 +168,22 @@ Every image is attempted before the run stops, so one failure does not hide the 
 
 If earlier runs left apps showing broken sheet icons, re-running `create-sheet-thumbnails` against those apps repairs them, once the upload problem itself is resolved. To clear the icons instead of regenerating them, use `qscloud remove-sheet-icons` — note this exists only for Qlik Sense Cloud.
 
+### I piped the output to `head` and got a crash report {#crash-report-from-piping}
+
+```bash
+butler-sheet-icons browser list-available --channel stable | head -12
+```
+
+Until BSI 5.0.0 that left a `crash_dumps` folder behind, in whatever directory you were standing in, with a report saying `write EPIPE`.
+
+Nothing had gone wrong. `head` stops reading once it has the lines you asked for, and the next line Butler Sheet Icons tried to print had nowhere to go. The same happened with a pager you quit early, and with `grep -m1`.
+
+::: warning Requires BSI 5.0.0 or later
+A closed output pipe is now an ordinary end to the run: no crash report, nothing printed, and your working directory is left as it was. The run exits with **141** rather than `1` — see [Exit code 141](/reference/commands#exit-code-141).
+:::
+
+**On an earlier version**, the dumps are harmless and safe to delete. Real failures are unaffected either way — a genuine error still writes a crash report, even when the output pipe has already closed. See [Crash Dump Files](/guide/advanced/crash-dumps#a-closed-output-pipe-is-not-a-crash).
+
 ### `Qlik Sense Cloud returned an unusable response` {#cloud-unusable-response}
 
 Butler Sheet Icons asked your tenant for a list — your collections, the apps in a collection, or the apps on the tenant — and what came back was not a list.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -61,6 +61,25 @@ Every command reports its outcome in the process exit code:
 | --------- | ----------------------------------------------------------------------------- |
 | `0`       | The command completed, and everything it was asked to do succeeded.           |
 | `1`       | The command failed, or finished with one or more apps it could not process.   |
+| `141`     | The command's output pipe closed before it finished writing — see below.      |
+
+### Exit code 141: the output pipe closed {#exit-code-141}
+
+::: warning Requires BSI 5.0.0 or later
+In earlier versions this situation produced a crash report and exit code `1`.
+:::
+
+A run whose output goes into a pipe that stops reading — `| head`, a pager you quit, `grep -m1` — ends with **141**. That is the usual convention on Linux and macOS for a program stopped by a closed pipe, `128 + 13`, where 13 is the `SIGPIPE` signal number. `ls | head` and most other tools report the same, and Butler Sheet Icons uses 141 on Windows too, for consistency.
+
+**It is deliberately not `0`.** Piping to `head` usually cuts a run short rather than letting it finish, and the exit code is meant to tell a scheduler whether the run did its job. Reporting success for work that was abandoned would be misleading.
+
+In practice this affects almost nobody:
+
+- **Running a command by hand** — you will never see it. The shell reports the exit code of the _last_ command in the pipeline, which is `head`, not Butler Sheet Icons.
+- **In a script using `set -o pipefail`** — the pipeline is reported as failed, exactly as it would be for `ls | head` in the same script. If you want the script to carry on, check for 141 specifically, or do not use `pipefail` on that line.
+- **In a scheduled task** — no change. A scheduled run writes to a log file or the console, not into a pipe that closes early.
+
+No crash dump is written for this, and nothing is printed about it — see [Crash Dump Files](/guide/advanced/crash-dumps#a-closed-output-pipe-is-not-a-crash).
 
 ### What counts as a failure
 


### PR DESCRIPTION
Published from the `piping-output-to-head-or-less.md` draft in `docs/to-doc-site`. **Last of the thirteen staged drafts.**

Piping to `head` used to leave a crash report behind, in whatever directory you happened to be standing in, saying `write EPIPE`. Nothing had gone wrong — `head` stops reading once it has its lines, and the next line printed had nowhere to go.

## Pages changed

The draft asked for all three, and each answers a different question:

| Page | What changed |
| --- | --- |
| `/guide/advanced/crash-dumps` | New **A closed output pipe is not a crash** section — for the reader arriving with "why is there a `crash_dumps` folder here?" |
| `/guide/troubleshooting` | New symptom entry, keyed on what the reader did rather than on the message |
| `/reference/commands` | **141** added to the exit code table, which documented only `0` and `1`, plus a section on why it is not `0` and who it affects |

## Verified against the implementation

All from `fatal-handlers.js`:

- `BROKEN_PIPE_EXIT_CODE = 141`, declared unconditionally — so the "141 on Windows too" claim holds
- No log line **and** no crash dump, and the reason for no log line is that the stream it would go to is the one that just died
- `BROKEN_PIPE_CODES` covers `ERR_STREAM_DESTROYED` as well as `EPIPE`
- The non-zero choice is deliberate, with the same reasoning the draft gives
- A genuine crash still writes its report even when the pipe has already closed — the two paths are separate

One nuance the draft does not have, from the module's own notes: the `uncaughtException` backstop is deliberately narrow, and in the rare case it misreads a socket failure as a broken pipe the dump is lost but the run is still reported as failed. That is a design note rather than something an administrator acts on, so it is recorded here rather than on the page.

## Verification

- `npm run docs:build` passes
- All three new anchors verified against the built HTML, and they cross-link in a triangle
- Heading hierarchy checked: the new crash-dumps section first landed mid-way through another section, orphaning its "Cleaning up dumps written by an older version" subsection; moved so both sit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)