### PR TITLE
Correct the wizard prompts and describe the supplied-answer checks

### DIFF
--- a/docs/guide/interactive-mode.md
+++ b/docs/guide/interactive-mode.md
@@ -187,16 +187,16 @@ Rather than typing an app ID from memory:
 
 ```
 ? Which apps should be updated?
-❯ Choose from all apps on the server
-  Choose a tag, then apps carrying it
-  Type an app id
+❯ Pick apps from a list
+  Update every app carrying a tag
+  Type app id(s)
 
 ? Which apps?
 ❯ ◯ Finance dashboard  (id: a1b2c3d4-1111-2222-3333-444455556666)
   ◯ Sales overview  (id: 9f8e7d6c-aaaa-bbbb-cccc-ddddeeeeffff)
 ```
 
-On Qlik Sense Cloud the middle choice is a collection rather than a tag, and collections are shown with the number of items they hold, so an empty one is obvious before you pick it:
+On Qlik Sense Cloud the middle route is a collection rather than a tag, and collections are shown with the number of items they hold, so an empty one is obvious before you pick it:
 
 ```
 ? Which collection?
@@ -208,6 +208,32 @@ On Qlik Sense Cloud the middle choice is a collection rather than a tag, and col
 
 Typing an ID directly is still offered, for when you already have it. And if the list cannot be fetched — a network problem, or an account without permission to read the app list — the wizard falls back to asking you to type the ID rather than stranding you.
 
+#### Choosing by tag or collection takes all of them
+
+The middle route does not show a list to tick, and cannot: a tag reaches Butler Sheet Icons as `--qliksensetag`, which selects **every** app carrying it, so offering a list there would invite a choice that could not be honoured. The wizard resolves the tag instead and tells you what it found:
+
+```
+? Which tag? BSI
+  7 app(s) carry the tag 'BSI' and will be updated.
+```
+
+A tag matching no apps is rejected at the prompt — `No apps on the server carry the tag 'BSI'.` — so you fix it there rather than discovering it when the run reports it had nothing to do.
+
+If you want only some of the tagged apps, use the list route instead.
+
+#### A run with nothing to do is refused
+
+Untick every app and the wizard says so rather than letting you confirm a run that would process nothing:
+
+```
+? Which apps?
+✖ No apps selected, so there would be nothing to do. Pick at least one app, or press Ctrl+C
+  and start again to choose a tag instead.
+? Which apps?
+```
+
+Naming no apps is still fine when a tag or collection is carrying the selection — the two add together, and one of them having apps is enough.
+
 ## Starting from the command you were typing
 
 Going through the menu means starting over even when you already know which command you want and have
@@ -217,43 +243,136 @@ half of it typed. `-i` on the command itself skips that:
 butler-sheet-icons browser uninstall -i
 ```
 
-### Anything you already supplied is kept
+### Two kinds of options, and only one of them is skipped
 
-This is the part worth knowing about. Options you have already given are treated as answers, not asked
-about again — so you can supply the parts you know and let Butler Sheet Icons ask for the rest:
+Options you have already given — on the command line, or through their `BSI_*` environment variables — are
+treated in one of two ways, and the wizard opens by telling you which is which:
+
+```
+Already supplied, so not asked about again: --host, --certfile, --certkeyfile,
+  --apiuserdir, --apiuserid, --logonuserdir, --logonuserid, --logonpwd, --contentlibrary.
+Supplied, but asked about again so you can change it for this run: --appid, --includesheetpart.
+```
+
+**Options that describe your environment are skipped.** A hostname, a port, a certificate path, a
+credential, a browser build, the content library — properties of the server you are pointing at. They stay
+true until the environment itself changes, so re-asking them every run is exactly the tedium `-i` exists to
+remove. This is what makes `-i` useful for filling the gaps in a command you have partly written:
 
 ```bash
-butler-sheet-icons browser install --browser-cache-dir D:\qlik\browsers -i
+butler-sheet-icons qseow create-sheet-thumbnails --host sense.acme.com -i
 ```
 
+**Options that describe this run are always asked**, opening on whatever you supplied. Which apps to
+update, which tag or collection to include, how much of each sheet to capture, which sheets to exclude or
+blur. These are decisions, not facts — and a decision taken once and left in a `.env` file should not be
+taken again silently on every later run, where you can neither see it nor change it without editing the
+file. Confirming one costs a single keystroke, because the question opens on the value already there.
+
+Values that merely fall back to a **default** are in neither group: they are asked about, with the default
+offered as the pre-filled answer. Only values you actually chose are treated as supplied.
+
+::: tip `browser uninstall` is the same rule, not an exception
+It asks one question standing in for both `--browser` and `--browser-version`, because it offers the builds
+actually in the cache. Supplying either does not skip it — a build id given from memory may name something
+no longer installed, so the list wins.
+:::
+
+### Skipped does not mean unchecked
+
+A skipped option is still **verified against your server**. Not asking about it does not mean trusting it:
+an API key can be revoked, a content library deleted, a certificate moved, long after the `.env` file
+naming them was written.
+
+**With a complete `.env` file the checks run before the first question**, because everything they need is
+already in the file:
+
 ```
-Ctrl+C cancels. Nothing is changed until you confirm at the end, where you can also start over.
-Already supplied, so not asked about again: --browser-cache-dir.
+── Checking what you supplied ────────────────────
 
-  Type to filter, or take one of the first two entries.
-? Which build should be installed?
-❯ Recommended - the build this version of Butler Sheet Icons is tested with
-  Latest stable - whatever the vendor currently publishes
+  ✓ --certfile (from BSI_QSEOW_CST_CERT_FILE) checked
+  ✓ --certkeyfile (from BSI_QSEOW_CST_CERTKEY_FILE) checked
+
+  ✓ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY) checked
 ```
 
-This is what makes `-i` useful for filling the gaps in a command you have partly written, not only for
-starting from nothing. It works for `BSI_*` environment variables too — a value set in your shell or in a
-`.env` file skips its question in exactly the same way.
+This is the common case once you have saved your answers, and the one worth having: a content library
+deleted last month is reported immediately, rather than after you have picked your way through a list of
+several hundred apps. Those lines are also why the wizard pauses for a moment — it is contacting your
+server.
 
-Values that merely fall back to a **default** are still asked about, with the default offered as the
-pre-filled answer. Only values you actually chose — on the command line or through the environment — are
-treated as settled.
+**A check waits when it depends on something you have not given yet.** The content library check opens a
+connection built from the host, the certificates and the API user, so if the host is not in your `.env`
+file the check cannot run until you have typed it, and happens further down instead. Nothing is skipped
+either way; only the timing differs.
 
-### One exception, and it says so
+**One check often covers several options**, and each gets its own line. The certificate check needs both
+paths and verifies both. On Qlik Sense Cloud the connection test does the same for `--tenanturl` and
+`--apikey` — a wrong tenant URL fails it as surely as a revoked key does.
 
-`browser uninstall` asks a single question that stands in for both `--browser` and `--browser-version`,
-because it offers the builds that are actually in the cache. Supplying either of those does not skip that
-question — a build id you gave from memory may name something that is no longer installed, so the list
-wins. Butler Sheet Icons tells you when this is happening:
+When a check fails, the wizard names the option, the environment variable the value came from, and what is
+wrong. It then asks the question after all, opening on the value that failed, so correcting it is an edit
+rather than a retype — except for a credential such as `--apikey`, which is a masked prompt and cannot be
+pre-filled:
 
 ```
-Supplied, but asked about again so the answer can be picked from what is actually there: --browser.
+  ✗ --contentlibrary (from BSI_QSEOW_CST_CONTENT_LIBRARY):
+    Content library 'Deleted last year' does not exist on sense.acme.com.
+    This check also uses these values you supplied: --host, --certfile.
 ```
+
+::: warning That last line matters when the value being complained about is not the one at fault
+A wrong `--host` in the same `.env` file makes the content library check fail too, and no amount of
+retyping the library name will fix it. Press **Ctrl+C**, correct the file, and start again.
+:::
+
+Without this, a stale `.env` file failed only once the run had started — on QSEoW, a missing content
+library aborts after every screenshot has already been taken.
+
+#### Apps you supplied are listed first, and ticked
+
+```
+  Apps you already supplied are listed first, ticked. Untick to leave one out.
+? Which apps?
+❯◉ Employee salaries  (id: ded8d27d-53b1-4d46-8d4e-44f552aeb8bc)
+ ◯ _s_QVD Generator - App scriptlog extract  (id: ede067b0-cbf9-4a2c-a422-bac1ffbdd4de)
+ ◯ User reload demo(2)  (id: ec31f83b-e8cd-41f8-846e-abd8b4e193ff)
+```
+
+First, not merely ticked. On a server with several hundred apps a ticked row sorted into the middle is one
+you would never see, so pressing Enter would quietly update an app you had not chosen for this run. At the
+top it takes one keystroke to remove.
+
+An app ID in your `.env` file naming an app the server no longer has is called out rather than vanishing
+from the selection without comment:
+
+```
+  ded8d27d-53b1-4d46-8d4e-44f552aeb8bc - supplied, but no longer on the server, so not listed below.
+```
+
+#### Sheet filters you supplied are shown even if you decline the gate
+
+A supplied `--exclude-sheet-number` or `--blur-sheet-tag` is shown even when you answer **no** to
+"Exclude or blur any sheets?". Declining means "nothing more", not "and forget what I already set" — the
+alternative would be a filter from your `.env` file silently skipping sheets behind a question you had just
+declined. Filters you have not set stay behind the gate as before.
+
+#### A supplied tag or collection is shown on every route
+
+`--qliksensetag` and `--collectionid` are not alternatives to naming apps — they are a second way of naming
+them, and the run covers both. So when one is already set, the wizard asks about it whichever route you
+picked:
+
+```
+? Which tag?
+  Every app carrying it is updated, on top of any apps named below. Leave empty for none.
+> BSI
+  7 app(s) carry the tag 'BSI' and will be updated.
+```
+
+Leave it empty — or choose `None - do not add a collection` in the collection list — and only the apps you
+picked are updated. Without this the tag would sit in your `.env` file and quietly widen every interactive
+run to apps you were never shown.
 
 ### Which commands accept it
 


### PR DESCRIPTION
Republished from `creating-thumbnails-interactively.md`, which was substantially rewritten in the BSI repo after I first published from it.

## Two things on the live site were wrong

Both from wizard changes that landed while the earlier pass was in flight:

| Page said | Code says |
| --- | --- |
| `Choose from all apps on the server` / `Choose a tag, then apps carrying it` / `Type an app id` | `Pick apps from a list` / `Update every app carrying a tag` / `Type app id(s)` |
| `Supplied, but asked about again so the answer can be picked from what is actually there` | `Supplied, but asked about again so you can change it for this run` |

## New behaviour, never documented

- **Choosing by tag resolves it at the prompt** and reports how many apps carry it, so a tag matching nothing is caught there rather than when the run reports it had nothing to do.
- **Unticking every app is refused.**
- **Supplied options are two kinds, not one.** Options describing the *environment* are skipped; options describing *this run* are asked anyway, opening on what you gave. This replaces the older framing, which said only that supplied options are kept.
- **A skipped option is still verified against the server** — before the first question when the `.env` file is complete enough. This is the part worth having: a content library deleted last month is reported immediately, rather than after picking through several hundred apps. Includes what happens when a check depends on something not yet given, when one check covers several options, and the line naming the *other* values a failing check read.
- **Apps you supplied are listed first and ticked**, not merely ticked — on a server with hundreds of apps a ticked row in the middle is one you would never see.
- Supplied **sheet filters** are shown even when you decline the exclude/blur gate, and a supplied **tag or collection** is shown on every route.

## A section that stopped being true

`browser uninstall`'s picker was documented as *"One exception, and it says so"* to the skipping rule. Under the two-kinds framing it is not an exception — it is an option describing this run — so it is now a note under that rule rather than a section arguing with it.

## One quote in the draft was already wrong

The draft has the empty-selection message offering to *"go back and choose a tag"*. There is no way back to a previous question — the page says so — and the code reads:

```
No apps selected, so there would be nothing to do. Pick at least one app, or press Ctrl+C and start again to choose <tag|collection> instead.
```

Published as the code has it.

## Verified against the implementation

All eight quoted strings located in `src/lib/interactive/spec-ops.js`, `src/lib/interactive/index.js` and the two thumbnail wizard files, and the two multi-part messages read in full rather than matched loosely.

## Verification

- `npm run docs:build` passes
- All five new anchors verified against the built HTML
- No dangling references to the two removed section anchors
- Code blocks all carry `overflow-x: auto`. The browser pane's viewport was collapsed this run so the pixel-level layout check was inconclusive; the structural property is what prevents sideways page scroll and it holds for all 29 blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)