### PR TITLE
Say that a floating browser build can still stop working

### DIFF
--- a/docs/guide/concepts/browser-management.md
+++ b/docs/guide/concepts/browser-management.md
@@ -148,9 +148,32 @@ Both are keywords rather than build numbers, so you do not need to know what Goo
 - **Every server on the same Butler Sheet Icons version uses the same browser build.** A fleet of scheduled jobs cannot drift apart on its own.
 - **No lookup at run time.** The build id is baked in, so once it is cached there is nothing to ask the vendor. With `stable`, every run first asks which build is currently newest.
 
-Choose `stable` only if you specifically need the newest stable release — for example because a security policy requires it. Be aware that it follows whatever the vendor has promoted, which can be a build newer than Butler Sheet Icons has been tested against.
+Choose `stable` only if you specifically need the newest stable release — for example because a security policy requires it. Be aware that it follows whatever the vendor has promoted, which can be a build newer than Butler Sheet Icons has been tested against, and eventually one it **cannot drive at all**. See [Every app fails with `Target closed` or `Protocol error`](/guide/troubleshooting#every-app-fails-with-target-closed-or-protocol-error) for what that looks like and why it can appear overnight.
 
 It also means a lookup on every run: on an offline or proxied machine that costs you connectivity you may not have. See [What `--browser-version` costs on an offline machine](/guide/concepts/browser-detection-and-environment-variables#what-browser-version-costs-on-an-offline-machine).
+
+### What `recommended` points at {#what-recommended-points-at}
+
+One exact Chrome build, decided by the browser automation library Butler Sheet Icons ships. It moves when that library is upgraded, which happens as part of upgrading Butler Sheet Icons — never on its own.
+
+Every run says which build it resolved to:
+
+```
+info: Browser version "recommended" resolved to chrome build 151.0.7922.71 (the build this version of Butler Sheet Icons is tested with)
+```
+
+**BSI 5.0.0 resolves `recommended` to Chrome `151.0.7922.71`.** In 4.1.0 it was `151.0.7922.47`.
+
+The practical consequence is that the first run after upgrading downloads the new build, and the previous one stays in the cache until you remove it:
+
+```bash
+butler-sheet-icons browser list-installed
+butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+```
+
+::: tip Read the build from the log, not from here
+This page states the build for the release named above. Your run tells you its own answer on the line quoted here, which is the one to trust — particularly if you are on a different version.
+:::
 
 Chrome's release **channels** are also accepted, and like `stable` they are resolved at run time: `beta`, `dev` and `canary`.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1337,7 +1337,26 @@ error: Failed to process 2 of 2 app(s)
 
 **Cause:**
 
-The Chrome build being used cannot be driven by Butler Sheet Icons. Before BSI 4.0.0 the default was `latest`, meaning the newest *published* Chrome build — and Chrome ships new builds continuously, so that was sometimes a build the browser automation library could not control. Two servers could behave differently purely because each had a different build sitting in its cache.
+The Chrome build being used cannot be driven by Butler Sheet Icons. Thumbnails are captured through a browser automation library, and that library is only tested against the Chrome builds current when it was released. Chrome's stable channel moves faster than the library does, so a build far enough ahead cannot be driven: Chrome launches normally, and the first instruction sent to it fails.
+
+Nothing is wrong with Chrome, and nothing is wrong with your Qlik Sense environment.
+
+Before BSI 4.0.0 the default was `latest`, meaning the newest *published* build, so this could strike anyone — two servers could behave differently purely because each had a different build cached. From 4.0.0 the default is `recommended` and that class of failure went away.
+
+::: warning It can still happen if you deliberately track Chrome's stable channel
+`recommended` cannot get ahead of what Butler Sheet Icons can drive. Anything that floats can:
+
+| `--browser-version` (or `BSI_*_BROWSER_VERSION`) | Can drift ahead? |
+| --- | --- |
+| `recommended` — the default | No |
+| `stable`, or its old alias `latest` | **Yes**, once Chrome's stable channel moves far enough ahead |
+| A release channel: `beta`, `dev`, `canary` | **Yes** |
+| An explicit recent build id, e.g. `151.0.7922.138` | **Yes** |
+
+Because `stable` means "whatever Chrome publishes as stable today", this appears overnight on a machine whose configuration has not been touched for months. That is the nature of the setting, not a fault in your environment.
+
+If you never set `--browser-version` and never set a `BSI_*_BROWSER_VERSION` variable, this does not apply to you.
+:::
 
 **Solutions:**
 
@@ -1359,10 +1378,16 @@ The Chrome build being used cannot be driven by Butler Sheet Icons. Before BSI 4
 3. **Install the recommended build ahead of time** so it is not downloaded during a scheduled run:
 
    ```bash
-   butler-sheet-icons browser install --browser chrome
+   butler-sheet-icons browser install
    ```
 
-See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build) for what each keyword selects.
+4. **Upgrade Butler Sheet Icons**, if you have a reason to keep tracking `stable`. Each release ships a browser automation library that drives the Chrome builds current at the time, so upgrading is what restores `stable` — pinning `recommended` is what avoids needing to.
+
+::: tip Should you go back to `stable` afterwards?
+Only if you have a specific reason to track Chrome's stable channel. `stable` will drift ahead of the tested build again — that is what it is for — and the failure above is what that looks like when it goes too far. `recommended` is the setting that keeps working without attention, and it needs no internet lookup, which also makes it the right choice on air-gapped and tightly firewalled machines.
+:::
+
+See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build) for what each keyword selects, and [what `recommended` currently points at](/guide/concepts/browser-management#what-recommended-points-at).
 
 ## Sheet-Specific Issues
 


### PR DESCRIPTION
Published from `browser-build-stops-responding-immediately.md` in `docs/to-doc-site`.

## Most of this draft was already published

The existing **Every app fails with `Target closed` or `Protocol error`** section already carries this exact symptom, quotes the same two error lines verbatim, and gives `--browser-version recommended` as the fix. A second section beside it would be two answers to one search, so this **extends** it instead.

## What was genuinely missing

The existing section frames the problem as historical — the default used to be `latest`, 4.0.0 changed it to `recommended`, fixed. True for anyone on the default, and why it reads as history.

**It is not fixed for anyone deliberately tracking Chrome's stable channel.** Chrome moves faster than the automation library that drives it, so `stable`, a release channel, or a pinned recent build will eventually name something that cannot be driven — arriving overnight on a machine nobody has touched for months.

Added:

- A table of which `--browser-version` settings can drift ahead, and which cannot
- That upgrading BSI is what restores `stable`, since each release ships a library that drives the Chrome builds current at the time
- Whether to go back to `stable` afterwards
- **What `recommended` actually resolves to**, which nothing on the site said

## Pages changed

| Page | What changed |
| --- | --- |
| `/guide/troubleshooting` | The `Target closed` section's cause rewritten, drift table added, upgrade fix added |
| `/guide/concepts/browser-management` | New **What `recommended` points at** section; the `stable` warning now says it can eventually name a build that cannot be driven at all, and links to the symptom |

## Verified against the implementation

The draft says `recommended` is Chrome `151.0.7922.71`, and was `151.0.7922.47` before. **Both correct**, but not straightforwardly:

- The repo's installed `node_modules` has `puppeteer-core` **25.4.0**, whose revision is `151.0.7922.47` — the *old* value. Reading the local install would have published the wrong build.
- `package.json` requires `^25.5.0` and the lockfile pins **25.5.0**, whose revision is `151.0.7922.71`.

So the figure was confirmed by installing 25.5.0 in a scratch directory and reading its `revisions.js`, not from the working tree.

All three quoted messages verbatim from `browser-launch.js` and `browser-version.js`.

## Corrected

The draft is gated `Requires BSI 4.2.0 or later` throughout. The release is **5.0.0**.

## Verification

- `npm run docs:build` passes
- `#what-recommended-points-at` and the two existing anchors linked from it verified against the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)