### PR TITLE
docs: drop the certificate holder's name from the Windows signing note

### DIFF
--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -12,7 +12,7 @@ If you discover a serious bug with BSI that may pose a security problem, please 
 
 ### Windows
 
-The Windows version of Butler Sheet Icons is signed with a code signing certificate issued by Certum, issued to "Open Source Developer, Göran Sander".
+The Windows version of Butler Sheet Icons is signed with a proper, commercial code signing certificate issued by Certum.
 
 ### macOS
 


### PR DESCRIPTION
## Description

The Windows section of the security page named the subject of the Certum code signing certificate ("Open Source Developer, Göran Sander"). What a reader needs from that sentence is that the Windows binary carries a real commercial signature — not who holds the certificate — so the page now says that and nothing more.

`/guide/installation` already described the same signature without a name ("digitally signed with a commercial certificate from Certum"), so the two pages now agree. The CA is kept on both; only the personal name is gone.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

- `/reference/security` — one sentence under **Platform-specific notes → Windows**

## Checklist

- [x] This PR targets `next` — see [Which branch?](../blob/next/.github/CONTRIBUTING.md#which-branch)
- [x] `npm run docs:build` passes locally (the build fails on dead internal links)
- [x] Internal links are absolute and extensionless, e.g. `/guide/quick-start`
- [x] New pages have a sidebar entry in `docs/.vitepress/config.js` — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Notes for reviewers

Two other occurrences of the name elsewhere on the site were left alone deliberately, since neither is about code signing:

- `/reference/security` — the liability disclaimer ("Ptarmigan Labs, Göran Sander, or any other contributor")
- `/examples/qscloud` — sample log output showing the signed-in Qlik user

Say the word if the CA name (Certum) should go too; that would touch `/guide/installation` as well.
