### PR TITLE
Explain why a cached browser was rejected

### DIFF
--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -54,20 +54,30 @@ If `PUPPETEER_EXECUTABLE_PATH` is set, BSI treats that as the preferred browser:
 
 If no system browser is configured, BSI looks in its browser cache directory. For a standalone build that is a `browser-cache` folder next to the executable; running from Node.js it is `.cache/puppeteer` in the current user's home directory. You can point it somewhere else with `--browser-cache-dir` or `BSI_BROWSER_CACHE_DIR` — see [Browser Cache Directory](/guide/advanced/browser-cache-directory) for the full order of precedence.
 
-A cached browser is used when it matches **both** of these:
+A cached browser has to pass **four** checks before it is used. All four must hold:
 
 - **Browser type** — the browser asked for with `--browser`. Every command accepts `chrome` only, and it is the default, so this matters only if you name it explicitly.
-- **Version** — if you specify an exact `--browser-version`, only a cached browser with exactly that build ID is used. If a different version is cached, BSI treats it as no match and downloads the version you asked for. If `--browser-version` is `latest` (the default), any cached build of the requested browser type is accepted.
+- **Operating system** — the build must be one this machine can actually run. A browser cache only works on the operating system it was downloaded for.
+- **The browser program is present** — the build's folder must still contain the browser itself. A folder left behind by an interrupted download, or by a copy that dropped files, does not count.
+- **Version** — `--browser-version` is resolved to one specific build, and only a cached browser with exactly that build id is used. If a different build is cached, BSI treats it as no match and downloads the one you asked for.
 
-When a cached browser matches, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.
+When a cached browser passes all four, it is used as-is and nothing is downloaded. This is what makes repeat runs fast: the browser is downloaded once and reused on every later run, with no network access needed for the browser itself.
 
 Use `butler-sheet-icons browser list-installed` to see which browsers are currently cached, and `browser install` to add one deliberately — for example when preparing a machine that will later run without internet access.
 
-::: tip "latest" means "anything cached", not "the newest available"
-With `--browser-version latest`, BSI does **not** check whether a newer browser has been released. Any cached build of the requested type is accepted, so a cached browser never updates itself. To move to a newer build, install it explicitly with `browser install --browser chrome --browser-version <build id>`, or clear the cache with `browser uninstall-all` and let the next run download a fresh one.
+::: warning Requires BSI 5.0.0 or later
+The operating system and browser-program checks were added in 5.0.0. Before that, a cache copied from a machine running a different operating system, or one whose browser files were incomplete, was accepted and used — and the run then failed later with an error that pointed at nothing in particular.
 
-If several builds of the same browser are cached, do not rely on which one gets picked. Pin `--browser-version` to an exact build ID whenever the exact version matters.
+If a cached browser is rejected, BSI now says which check it failed and where it looked. The three messages, and what to do about each, are in [Troubleshooting](/guide/troubleshooting#a-cached-browser-was-rejected).
 :::
+
+::: tip Version keywords are not wildcards
+`recommended` (the default), `stable` and `latest` each resolve to **one specific build** before the cache is searched. No keyword means "accept anything I have cached", so switching from one to another will not make BSI accept a build it has already rejected — it simply looks for a different specific build.
+
+To use a browser you already have, pin `--browser-version` to its exact build id. `browser list-installed` prints them. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build) for what each keyword means.
+:::
+
+A browser named with `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH` or with `PUPPETEER_EXECUTABLE_PATH` is not subject to any of this — that is step 1 above, and such a browser is used as-is, without these checks.
 
 ::: warning Requires BSI 4.0.0 or later
 In earlier versions a defect prevented BSI from ever finding a cached browser, so in practice it re-downloaded a browser on **every run** unless `PUPPETEER_EXECUTABLE_PATH` was set. From 4.0.0 the cache is used as described above. Nothing needs to be reconfigured — the improvement applies automatically, and repeat runs start faster and use far less bandwidth.
@@ -268,11 +278,20 @@ Typical flow:
 2. Copy the Puppeteer cache directory to the target machine
 3. Run BSI on the target machine without any browser env vars set
 
+::: warning The connected machine must run the same operating system
+A browser cache only works on the operating system it was downloaded for. Staging on an administrator's Mac for a Windows Server does not work, and from 5.0.0 BSI says so rather than failing later for no visible reason — see [A cached browser was rejected](/guide/troubleshooting#a-cached-browser-was-rejected).
+
+Stage the build the target machine will actually ask for, too. Both machines should use the same `--browser-version`, and leaving it at the default `recommended` on both is the simplest way to guarantee that.
+:::
+
 **Example outline (PowerShell + bash mix):**
 
 ```powershell
-# 1. On a connected machine, install a browser into the cache
-butler-sheet-icons browser install --browser chrome --browser-version latest
+# 1. On a connected machine, install a browser into the cache.
+#    "recommended" is the default and is a fixed build, so the target machine
+#    looks for exactly this one. Do not use "latest" here: it resolves to
+#    whatever is newest today, which is unlikely to be what the target asks for.
+butler-sheet-icons browser install --browser chrome --browser-version recommended
 ```
 
 ```bash

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -743,6 +743,8 @@ On an air-gapped server, or one behind a proxy that blocks outbound HTTPS, the t
 
 Creating thumbnails itself does not need internet access once a browser is available locally. For the full picture, see [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access).
 
+If you staged a browser on the machine and BSI still tries to download one, it has rejected what you copied — see [A cached browser was rejected](#a-cached-browser-was-rejected) for the message it printed and what each one means.
+
 ### The run hangs after "Launching browser..." {#the-run-hangs-after-launching-browser}
 
 **Symptoms:**
@@ -1028,6 +1030,112 @@ when Butler Sheet Icons runs on Windows. See
    :::
 
    This is also the fix when a scheduled task cannot find the browser you installed by hand — the two accounts have different home directories. See [Browser Cache Directory](/guide/advanced/browser-cache-directory).
+
+### A cached browser was rejected {#a-cached-browser-was-rejected}
+
+::: warning Requires BSI 5.0.0 or later
+These messages were added in 5.0.0. In earlier versions the same situations produced no message at all: the browser was accepted, the log said which browser was being used, and the run failed later with an error that named none of this.
+:::
+
+**Symptoms:**
+
+- You staged a browser on the machine, but BSI tries to download one anyway
+- The run fails on a server with no internet access, after a warning about the browser cache
+- `browser list-installed` shows a build, but BSI does not use it
+
+**Cause:**
+
+A cached browser has to pass four checks before BSI will use it — the right browser, built for this operating system, with the browser program actually present, and matching the build that `--browser-version` resolved to. See [Cached browser](/guide/concepts/browser-detection-and-environment-variables#_2-cached-browser-medium-priority).
+
+When no cached browser passes, BSI reports the check that stopped it. The three messages below are the ones you will see.
+
+#### The cache came from a different operating system
+
+```
+Found 1 cached chrome build(s), but none built for this machine (platform "win64").
+Cached chrome builds are for: mac_arm. A browser cache copied from a machine with a
+different operating system cannot be used.
+Browser cache directory: C:\butler-sheet-icons\browser-cache
+```
+
+This is the most common mistake when staging a browser for a server with no internet access, because the connected machine is usually an administrator's Mac or Windows laptop while the target is a Windows Server running Qlik Sense.
+
+**A browser cache only works on the operating system it was downloaded for.** A cache prepared on macOS cannot be used on Windows, and neither can be used on Linux.
+
+The message names both sides: the platform this machine needs, and the platforms the cached builds were built for. The names are the ones the browser download service uses:
+
+| Name        | Operating system         |
+| ----------- | ------------------------ |
+| `win64`     | 64-bit Windows           |
+| `win32`     | 32-bit Windows           |
+| `mac_arm`   | macOS on Apple Silicon   |
+| `mac`       | macOS on Intel           |
+| `linux`     | 64-bit Linux             |
+| `linux_arm` | Linux on ARM             |
+
+Two combinations are **not** a mismatch, because the machine can run the build even though the names differ. BSI accepts both without a warning:
+
+- A **32-bit Windows** (`win32`) build on **64-bit Windows** (`win64`)
+- An **Intel macOS** (`mac`) build on **Apple Silicon** (`mac_arm`), which runs through Rosetta. This assumes Rosetta is installed, as it normally is; if it is not, the browser will fail to start.
+
+Everything else must match. In particular, no Windows build runs on Linux or macOS, and no 64-bit build runs on a 32-bit or ARM host.
+
+**Solution:** download the browser again on a machine running the same operating system as the target, and copy that cache across instead. On a machine with internet access, simply let BSI download a browser itself.
+
+#### The cache is incomplete
+
+```
+Found 1 cached chrome build(s) for this machine, but none has a usable executable. The
+cache directory may be incomplete - for example copied without the browser binary, or
+left behind by a failed install.
+Browser cache directory: C:\butler-sheet-icons\browser-cache
+```
+
+The cache folder is there and looks right, but the browser program inside it is missing. This usually means the copy did not include everything, or that an earlier download was interrupted.
+
+**Solution:** delete the incomplete folder and copy or download the browser again.
+
+If you are copying from another machine, **make sure your archiving tool includes hidden files** — several skip them by default, and one of the files BSI needs is hidden.
+
+To check a copy, list the installed browsers and then confirm the browser program is really present in the folder shown:
+
+```bash
+butler-sheet-icons browser list-installed
+```
+
+That command prints the installation folder for each cached build. Note that it lists a build whether or not the browser program inside it survived the copy, so seeing the build listed is **not** by itself proof that the copy is complete — open the folder and confirm the browser program is there.
+
+#### The requested browser version is not the one you have
+
+```
+No cached chrome build matches --browser-version "recommended" (build 138.0.7204.94).
+Cached chrome builds that this machine can run: 131.0.6778.204. Set --browser-version to
+one of those build ids to use it instead.
+Butler Sheet Icons will now try to download chrome 138.0.7204.94, which needs internet
+access. On a machine without internet access this will fail.
+```
+
+The build BSI was asked for is not the one in the cache. On a machine with internet access this is only a warning: the requested build is downloaded and the run continues. On a machine without internet access the download cannot succeed, so the run fails.
+
+The message names the version **as you set it**, with the exact build it resolved to in brackets. You will see a bracketed build even if you never set `--browser-version` at all: the default, `recommended`, is a name for one specific build that BSI ships with, and that build is what gets looked for in the cache.
+
+**Solution:** set `--browser-version` to one of the build ids the message lists, which uses the browser you already have:
+
+```bash
+butler-sheet-icons browser list-installed
+```
+
+The alternative is to stage the exact build it asked for.
+
+::: tip Version keywords are not wildcards
+`recommended`, `stable` and `latest` each resolve to **one specific build** before the cache is searched. Switching from one keyword to another will not make BSI accept a build it already rejected — it will simply look for a different specific build. Only an exact build id from the list in the message is guaranteed to match what you have. See [Choosing a browser build](/guide/concepts/browser-management#choosing-a-browser-build).
+:::
+
+#### What has not changed
+
+- A healthy cache behaves exactly as before, with no new messages. A single unusable folder sitting beside a working browser is ignored quietly.
+- A browser named with `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH`, or with `PUPPETEER_EXECUTABLE_PATH`, is used as-is and is not subject to these checks.
+- Where the browser cache lives, and how to change it with `--browser-cache-dir` or `BSI_BROWSER_CACHE_DIR`, is unchanged — see [Browser Cache Directory](/guide/advanced/browser-cache-directory).
 
 ### Platform-Specific Browser Issues
 


### PR DESCRIPTION
Publishes `docs/to-doc-site/browser-cache-checked-before-use.md` from the BSI repo.

BSI 5.0.0 adds two checks on a cached browser — that it was built for this operating system, and that the browser program is actually present. Previously both failures were accepted silently and the run failed later with an unrelated-looking error.

## Changes

**`guide/troubleshooting.md`** — new entry "A cached browser was rejected", with the three messages quoted verbatim, a platform-name table, the two combinations that are deliberately *not* a mismatch (win32 on win64, Intel macOS on Apple Silicon), and what to do about each.

**`guide/concepts/browser-detection-and-environment-variables.md`** — the cached-browser section now describes four checks rather than two, and links to the new entry.

## Corrections to text that was already live

- The section said a cached browser is used when it matches **both** browser type and version. It is now four checks.
- It said `--browser-version latest` is **the default** and that any cached build is then accepted. The default is `recommended`, and since the version-selection work every keyword resolves to exactly one build before the cache is searched. The `"latest" means "anything cached"` tip was wholly false and is replaced.
- The semi-offline staging example installed with `--browser-version latest`, which resolves to whatever is newest that day and therefore will not match the `recommended` build the target machine looks for — the example produced the very failure the new entry documents. Now uses `recommended`, with a warning that both machines must run the same operating system.

## Verification

- `npm run docs:build` passes.
- Anchors checked against the generated HTML: `#a-cached-browser-was-rejected`, `#_2-cached-browser-medium-priority`, `#choosing-a-browser-build`.
- All three messages checked fragment-by-fragment against `src/lib/browser/browser-detect.js` in both directions, so the quotes are verbatim rather than paraphrased.
- `npm run docs:cli-tables -- ... --check` reports every generated table current.