### PR TITLE
Correct the claim that browser install always needs internet access

### DIFF
--- a/docs/guide/concepts/browser-detection-and-environment-variables.md
+++ b/docs/guide/concepts/browser-detection-and-environment-variables.md
@@ -104,7 +104,20 @@ The `browser` management commands are different — only some of them reach out 
 | `browser list-installed`             | **No.** Reads the local Puppeteer cache only. |
 | `browser uninstall` / `uninstall-all` | **No.** Removes browsers from the local cache. |
 | `browser list-available`             | **Yes.** It asks Google's Chrome version history service which versions exist. |
-| `browser install`                    | **Yes**, always. BSI verifies that the requested build can actually be downloaded before installing it, so the command needs internet access even when that version is already in the cache. |
+| `browser install`                    | **Only when it has work to do.** No internet is needed if the build you asked for is already in the cache *and* `--browser-version` names it without a lookup. Otherwise yes — to download the build, or to resolve the version name. See below. |
+
+::: warning Requires BSI 5.0.0 or later
+Before 5.0.0, `browser install` checked that the build could be **downloaded** before it looked at what was already on the machine, so it needed internet access even for a browser sitting on disk. It now looks in the cache first.
+
+This is what lets you confirm a staged browser **on the air-gapped machine itself** — previously the one check that could not be done there. See [`browser install`](/reference/browser#install).
+:::
+
+Whether `browser install` can run offline therefore comes down to two things:
+
+1. **The build must already be in the cache**, built for this machine, with the browser program present.
+2. **`--browser-version` must not need a lookup.** `recommended` (the default) and an exact full build id are answered from information BSI already has; `stable`, `latest`, a channel, a milestone or a build prefix all have to be asked about. The table in [What `--browser-version` costs on an offline machine](#what-browser-version-costs-on-an-offline-machine) says which is which, and it applies here exactly as it does to a thumbnail run.
+
+So `butler-sheet-icons browser install`, with no options at all, completes offline on a machine with the matching browser staged — the default `recommended` needs no lookup.
 
 On a machine with no internet access — an air-gapped server, or one behind a proxy that blocks outbound HTTPS — `browser list-available` reports:
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -699,16 +699,22 @@ Browser-related problems are among the most common issues when using Butler Shee
 
 **Cause:**
 
-Two of the `browser` commands need internet access, and the rest do not:
+Some of the `browser` commands need internet access, and the rest do not:
 
-| Command                               | Needs internet? |
-| ------------------------------------- | --------------- |
-| `browser list-installed`              | No              |
-| `browser uninstall` / `uninstall-all` | No              |
-| `browser list-available`              | Yes, for Chrome |
-| `browser install`                     | Yes, always     |
+| Command                               | Needs internet?                          |
+| ------------------------------------- | ---------------------------------------- |
+| `browser list-installed`              | No                                       |
+| `browser uninstall` / `uninstall-all` | No                                       |
+| `browser list-available`              | Yes, for Chrome                          |
+| `browser install`                     | Only if it has to download or look up a version |
 
-On an air-gapped server, or one behind a proxy that blocks outbound HTTPS, the two commands that need internet access will fail. This is expected behaviour, not a fault in BSI.
+On an air-gapped server, or one behind a proxy that blocks outbound HTTPS, the commands that need internet access will fail. This is expected behaviour, not a fault in BSI.
+
+::: warning `browser install` used to fail here even when the browser was present
+Before 5.0.0, `browser install` checked that the build could be **downloaded** before it looked at what was already on the machine — so on an offline server it reported that a browser sitting right there on disk `cannot be downloaded`, and pointed at `browser list-available`, which needs internet access too.
+
+From 5.0.0 the cache is checked first, so confirming a staged browser works on the air-gapped machine itself. Two conditions have to hold: the build must already be staged for this machine, and `--browser-version` must be one that needs no lookup — `recommended` (the default) or an exact full build id. See [Installing a browser that is already there](/reference/browser#install-already-present).
+:::
 
 **Solutions:**
 
@@ -721,9 +727,14 @@ On an air-gapped server, or one behind a proxy that blocks outbound HTTPS, the t
 2. **Prepare the machine while it still has connectivity**:
 
    ```bash
-   # Run once on a connected machine; the browser is cached and reused afterwards
-   butler-sheet-icons browser install --browser chrome --browser-version latest
+   # Run once on a connected machine; the browser is cached and reused afterwards.
+   # Leave --browser-version at its default: "recommended" is a fixed build that
+   # needs no lookup, so later runs work offline. "latest" resolves to whatever is
+   # newest that day, which is not what the offline machine will ask for.
+   butler-sheet-icons browser install --browser chrome
    ```
+
+   From 5.0.0 you can re-run the same command on the offline machine to confirm the browser is really there — it checks the cache before the network, and reports `is already installed at ...` without downloading anything.
 
 3. **Or point BSI at a browser installed by other means** — no download and no internet access needed:
 

--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -22,7 +22,7 @@ butler-sheet-icons browser [command] [options]
 | ---------------- | ------------------------------------------------------------------------ | --------------- |
 | `list-installed` | Show which browsers are currently installed and available for use by BSI | No              |
 | `list-available` | Show which browsers are available for download and installation          | Yes (Chrome)    |
-| `install`        | Install a browser into the BSI cache                                     | Yes             |
+| `install`        | Install a browser into the BSI cache                                     | Only if it has to download or look up a version — see [below](#install) |
 | `uninstall`      | Uninstall a specific browser from the BSI cache                          | No              |
 | `uninstall-all`  | Uninstall all browsers from the BSI cache                                | No              |
 | `help`           | Display help for browser commands                                        | No              |
@@ -170,9 +170,58 @@ The keywords `recommended` and `stable` are also accepted, as are Chrome's relea
 If you try to install an older Chrome version that's no longer available, you'll get a 404 error. The Chrome team periodically removes older versions from their download servers. Use a newer version instead.
 :::
 
-::: warning Needs internet access
-`browser install` always needs internet access — it verifies that the requested build can actually be downloaded before installing it, so the check runs even when that version is already in the cache. Run it once while the machine is connected; the browser is then stored in the cache and reused on later runs without connectivity. See [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access).
+#### Installing a browser that is already there {#install-already-present}
+
+::: warning Requires BSI 5.0.0 or later
+Before 5.0.0, `browser install` checked that the build could be **downloaded** before it looked at what was already on the machine. On a server with no internet access that check failed, and the command reported that a browser sitting right there on disk `cannot be downloaded`. The suggested next step, `browser list-available`, needs internet access too, so there was no way forward.
 :::
+
+BSI now looks in the cache first. If the build you asked for is already there, it says so and stops, using no network at all:
+
+```
+chrome 151.0.7922.47 is already installed at
+C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.47. Nothing to download.
+To replace it, remove it first with "butler-sheet-icons browser uninstall
+--browser-version 151.0.7922.47".
+```
+
+This is what lets you **confirm a staged browser on the air-gapped machine itself**. It also means `browser install` is now a **no-op when the requested build is already present** — it reports what is installed and exits successfully rather than installing over the top. To replace an installed browser, uninstall it first:
+
+```bash
+butler-sheet-icons browser uninstall --browser-version 151.0.7922.47
+```
+
+##### When it still needs internet access
+
+Two separate things can require the network, and both must be avoided for a fully offline install:
+
+| | Needs internet? |
+| --- | --- |
+| Resolving `--browser-version` | Depends on the value. `recommended` (the default) and an exact full build id such as `151.0.7922.77` need no lookup. `stable`, `latest`, a channel, a milestone (`151`) or a build prefix (`151.0.7922`) all do — see [What `--browser-version` costs on an offline machine](/guide/concepts/browser-detection-and-environment-variables#what-browser-version-costs-on-an-offline-machine). The lookup happens **before** the cache is consulted, so those values fail offline even when the browser is present. |
+| Fetching the build | Only when the build is not already in the cache for this machine. |
+
+So `butler-sheet-icons browser install`, with no options at all, completes offline on a machine with the matching browser staged.
+
+##### Three cases where it still downloads
+
+**A different build.** The cache holds a different version from the one requested. See [A cached browser was rejected](/guide/troubleshooting#a-cached-browser-was-rejected) — the message lists the build ids you have.
+
+**A build for a different operating system.** Installing is about placing *this* machine's build, so a foreign build never counts as already installed. Note this is **stricter than the check made when taking screenshots**, which accepts a 32-bit Windows build on 64-bit Windows, or an Intel macOS build on Apple Silicon. Installing requires an exact platform match.
+
+**A folder with no browser in it.** If the build's folder exists but the browser program inside it is missing — an incomplete copy, or an interrupted download — you will see:
+
+```
+A cached chrome 151.0.7922.47 directory exists at
+C:\butler-sheet-icons\browser-cache\chrome\win64-151.0.7922.47, but the browser executable
+is missing from it. Butler Sheet Icons will remove that directory and install the build
+again, which needs internet access.
+```
+
+BSI removes the incomplete folder itself and installs the build again, which works on a machine with internet access. Nothing is lost by the removal: a folder with no browser program in it cannot be used for anything.
+
+On an air-gapped machine the reinstall cannot succeed, so copy the browser across again — making sure your archiving tool includes hidden files, as several skip them by default and one of the files BSI needs is hidden.
+
+See also [Which browser commands need internet access?](/guide/concepts/browser-detection-and-environment-variables#which-browser-commands-need-internet-access).
 
 ### uninstall
 


### PR DESCRIPTION
Publishes `docs/to-doc-site/browser-install-works-offline.md` from the BSI repo.

From 5.0.0, `browser install` looks in the cache before the network. If the requested build is already staged it reports that and stops, using no network at all — which is what lets an administrator confirm a staged browser **on the air-gapped machine itself**, previously the one check that could not be done there.

## Changes

**`reference/browser.md`** — new "Installing a browser that is already there" section: the two messages verbatim, the no-op-when-present behaviour, what still requires the network, and the three cases where it downloads anyway.

**`guide/concepts/browser-detection-and-environment-variables.md`** — the `browser install` row in the internet-access table.

**`guide/troubleshooting.md`** — the same row in the offline-commands table, plus a callout for anyone who hit the old failure.

## Corrections

Three live places said `browser install` **always** needs internet access. The concepts page also gave the reason — that BSI verified the build could be downloaded before installing it — which is exactly the precheck that was removed.

**The draft was also wrong, in both directions.** It said the values needing a lookup are "`latest`, `stable`, or a release channel". Verified empirically by blocking the socket layer and resolving each value:

| `--browser-version` | Resolves offline? |
| --- | --- |
| `recommended` (default) | Yes |
| full build id `151.0.7922.47` | **Yes** — the draft implied otherwise |
| `stable` / `latest` / channel | No |
| build prefix `151.0.7922` | **No** — the draft omitted this |
| milestone `151` | **No** — the draft omitted this |

The site already had this matrix, correctly, under "What `--browser-version` costs on an offline machine". The new text points at it rather than restating it.

Also fixed a staging example that installed with `--browser-version latest`, which resolves to whatever is newest that day and so cannot match what the offline machine asks for.

## Verification

- `npm run docs:build` passes.
- Both messages checked fragment-by-fragment against `src/lib/browser/browser-install.js` in both directions.
- Anchors checked against generated HTML: `#install-already-present`, `#what-browser-version-costs-on-an-offline-machine`, `#which-browser-commands-need-internet-access`, `#a-cached-browser-was-rejected`, `#install`.
- `docs:cli-tables --check` reports every generated table current.