### PR TITLE
Correct three log messages that are quoted from older releases

### DIFF
--- a/docs/examples/browser-management.md
+++ b/docs/examples/browser-management.md
@@ -245,8 +245,12 @@ Chromium 150.0.7871.181 Alpine Linux
 Passing `--browser-version` to a thumbnail command in the container does not change which browser runs. Butler Sheet Icons uses the embedded one and tells you it has done so:
 
 ```
-warn: PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.
+warn: The browser executable from PUPPETEER_EXECUTABLE_PATH overrides --browser-version "121.0.6167.85": the browser at /usr/bin/chromium-browser will be used instead. Unset PUPPETEER_EXECUTABLE_PATH to use the requested build.
 ```
+
+::: warning Wording changed in BSI 5.0.0
+Before 5.0.0 this warning began `PUPPETEER_EXECUTABLE_PATH overrides ...`, without the leading `The browser executable from`. It had to name **which** setting won, because from 5.0.0 there are two that can: `--browser-executable-path` / `BSI_BROWSER_EXECUTABLE_PATH`, and `PUPPETEER_EXECUTABLE_PATH`. Searching your logs for the old wording will not match a 5.0.0 run.
+:::
 
 Worse, on a machine without internet access, some values of `--browser-version` will make the run **fail** while still not changing the browser — because the version has to be resolved before the browser is chosen. Leave it at its default, `recommended`, when running in Docker. The reasoning is in [Browser versions on an air-gapped host](/guide/advanced/docker#browser-versions-on-an-air-gapped-host).
 

--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -122,10 +122,10 @@ Source: uncaughtException
 Exit Code: 1
 
 === ERROR MESSAGE ===
-Failed to install a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
+Could not obtain a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
 
 === STACK TRACE ===
-QseowError: Failed to install a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
+QseowError: Could not obtain a browser for QSEoW app a3e0f5d2-000a-464f-998d-33d333b175d7
     at src/lib/qseow/qseow-process-app.js:282:1
     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
 
@@ -133,6 +133,14 @@ QseowError: Failed to install a browser for QSEoW app a3e0f5d2-000a-464f-998d-33
 END OF CRASH REPORT
 ====================================
 ```
+
+::: warning This message was reworded in BSI 5.0.0
+Dumps written by earlier versions say `Failed to install a browser for ...` where 5.0.0 says **`Could not obtain a browser for ...`**. Both name the same problem, so search for either when going through older dumps.
+
+The old wording claimed an install had been attempted, which is no longer true in general: with [`--browser-executable-path`](/guide/concepts/browser-detection-and-environment-variables#browser-you-named) set to a file that does not exist, the run stops before any download is considered — and being told an install failed sent people looking for a network problem they did not have.
+
+The same rename applies to the Qlik Sense Cloud form, `Could not obtain a browser for Qlik Sense Cloud app <id>`.
+:::
 
 ## How are secrets handled in crash dumps?
 

--- a/docs/guide/advanced/docker.md
+++ b/docs/guide/advanced/docker.md
@@ -342,7 +342,7 @@ The commands in this section are written for a Linux shell, since that is where 
 info: Browser version "recommended" resolved to chrome build 150.0.7871.24 (the build this version of Butler Sheet Icons is tested with)
 info: Checking for available browsers...
 info: Found system browser at: /usr/bin/chromium-browser
-info: Using system browser (PUPPETEER_EXECUTABLE_PATH is set)
+info: Using system browser (from PUPPETEER_EXECUTABLE_PATH)
 info: Browser ready from system: chrome system-installed
 ```
 
@@ -419,7 +419,21 @@ The bottom line: **inside the Docker image, `--browser-version` cannot change wh
 
 ### If you do not want the embedded browser
 
-Some organizations require a centrally approved browser build rather than the one in the image. Set `PUPPETEER_EXECUTABLE_PATH` to an empty string and mount a browser cache from the host, and Butler Sheet Icons will use that instead. This needs no internet either, as long as the cache is populated before the machine goes offline.
+Some organizations require a centrally approved browser build rather than the one in the image. There are two ways to do it.
+
+**Point at a specific browser inside the container.** From 5.0.0, `BSI_BROWSER_EXECUTABLE_PATH` takes precedence over the `PUPPETEER_EXECUTABLE_PATH` the image sets, so it overrides the embedded browser directly:
+
+```bash
+docker run --rm \
+  -v /opt/browsers:/browsers \
+  -e BSI_BROWSER_EXECUTABLE_PATH=/browsers/chrome/chrome \
+  ptarmiganlabs/butler-sheet-icons:latest \
+  qseow create-sheet-thumbnails ...
+```
+
+The browser must be a **Linux** build, since that is what the container runs. If the path does not exist the run stops rather than falling back to the embedded browser — that is the point of the option, and it is what makes the override auditable. See [A browser you named](/guide/concepts/browser-detection-and-environment-variables#browser-you-named).
+
+**Or mount a browser cache.** Set `PUPPETEER_EXECUTABLE_PATH` to an empty string and mount a browser cache from the host, and Butler Sheet Icons will use that instead. This needs no internet either, as long as the cache is populated before the machine goes offline.
 
 That is described on [Browser detection and environment variables](/guide/concepts/browser-detection-and-environment-variables#docker-image-with-external-browser) and is not repeated here.
 


### PR DESCRIPTION
Publishes `docs/to-doc-site/two-renamed-messages.md` from the BSI repo.

This is a correction pass, not a new topic. Three messages are quoted as literal sample output on pages that are **already live**, and the quoted text is not what BSI emits any more. That is the case where a stale quote does real damage: administrators search for the string they saw.

## The three

**1. The version-override warning** — `examples/browser-management.md`

Now begins `The browser executable from PUPPETEER_EXECUTABLE_PATH overrides ...`. It had to name *which* setting won, because from 5.0.0 two can.

**2. The browser failure wrapper** — `guide/advanced/crash-dumps.md`, twice

`Failed to install a browser for ...` → `Could not obtain a browser for ...`, because nothing necessarily tried to install: an explicitly named `--browser-executable-path` that does not exist fails before any download is considered. Added a callout so anyone comparing an **older** dump still finds the entry.

**3. The system-browser line** — `guide/advanced/docker.md`

`Using system browser (PUPPETEER_EXECUTABLE_PATH is set)` → `Using system browser (from PUPPETEER_EXECUTABLE_PATH)`.

## Two corrections to the draft

**The draft names the wrong page for #1.** It says `guide/advanced/docker.md`, quoting it twice. The string is not on `docker.md` at all — it is on `docs/examples/browser-management.md`, once.

**The draft does not mention #3.** Found by sweeping the site for the message rather than trusting the draft's list. It sits inside a block the Docker page presents as proof that an air-gapped run never reached the internet, so a wrong line there is worse than average. I verified **every** line of that block against source; the other four are correct.

## Also

Added the `BSI_BROWSER_EXECUTABLE_PATH` override to the Docker page's "If you do not want the embedded browser" section, which previously offered only the mounted-cache route.

## Verification

- `npm run docs:build` passes.
- All quotes checked against `browser-detect.js`, `browser-paths.js` and `browser-launch.js` in both directions, including the label/removal fragments the override warning is assembled from.
- Confirmed the old strings appear **zero** times inside code blocks, and that the one remaining mention of the old install wording is the deliberate "was reworded" prose.