### PR TITLE
Extend the closed output pipe section to cover captured output

### DIFF
--- a/docs/guide/advanced/crash-dumps.md
+++ b/docs/guide/advanced/crash-dumps.md
@@ -259,6 +259,10 @@ Nothing had gone wrong. `head` stops reading once it has the twelve lines you as
 
 A closed output pipe is now treated as an ordinary end to the run. **No crash dump is written, and nothing is printed about it** — the stream any message would go to is the one that just died. The command above leaves your working directory exactly as it found it, and the output itself is unchanged: you still get the same twelve lines.
 
+This applies whether the reader is a command such as `head`, a pager you quit early, or **another program that started Butler Sheet Icons and captured its output** — a wrapper script, a job runner, or a scheduling tool. If you have seen occasional unexplained crash reports from a run driven by another tool, with `write ENOTCONN` or `write ECONNRESET` as the error message, that is what they were.
+
+The reason they were only occasional is invisible from the outside: output captured by another program travels over a slightly different kind of connection than output piped to `head`, and which of the two messages a dead connection reports depends on whether anything was still buffered when the reader went away. On a busy machine the reader reacts later and more has piled up behind it, so these were most likely exactly where they were hardest to reproduce.
+
 The run ends with exit code **141** rather than `0`; see [Exit code 141](/reference/commands#exit-code-141) for why, and who it affects.
 
 ### Real failures are unaffected
@@ -268,6 +272,7 @@ Worth being clear about, because the two can happen together:
 - A genuine error still writes one `.json` and one `.txt` crash report and exits with code **1**, with its `FATAL:` line in the log.
 - That remains true **even when the output pipe has already closed**. If a run crashes for a real reason while you happen to be piping it through `head`, you still get the crash report you need.
 - A failure to write output for any *other* reason — a full disk, a permission problem — is still a genuine error and still produces a crash report.
+- **A lost connection to Qlik Sense still produces a crash report.** This is the case worth knowing about, because a dropped server connection and a reader that stopped reading can surface with the same error name. Butler Sheet Icons only takes the quiet path when it knows the failure was its own output; anything else keeps its crash report and exit code 1, which is what you need when a run against a Qlik Sense server fails halfway. See [The connection to Qlik Sense drops in the middle of a run](/guide/troubleshooting#engine-session-dropped-mid-run).
 
 The `BSI_CRASH_DUMP_*` variables are unchanged, and so is the one-dump-per-run behaviour above.
 


### PR DESCRIPTION
Publishes `docs/to-doc-site/closed-output-pipe-when-another-program-reads-the-output.md` from the BSI repo.

This extends an existing section rather than adding a page — the draft says so itself, and the site already covers the `| head` case.

## What changed

The section already promised that a closed output pipe is an ordinary end to the run: no crash dump, exit code 141. That held only when the reader was something like `head`. When the thing reading the output was **another program** — a wrapper script, a job runner, a scheduling tool — BSI still wrote a crash report and exited 1, which is precisely what the section says no longer happens.

Two additions:

1. A paragraph stating the promise holds however the output is read, naming `write ENOTCONN` and `write ECONNRESET` so anyone who kept one of those crash reports can match it, and explaining why they were intermittent.
2. A bullet under "Real failures are unaffected": **a lost connection to Qlik Sense still produces a crash report.** This is the one worth stating, because a dropped server connection and a reader that stopped reading can surface with the same error name.

## Version gate

None added. The section already carries `Requires BSI 5.0.0 or later`, and this ships in 5.0.0 too — confirmed from release-please PR #974, not from the draft.

## Verification

Claims checked against `src/lib/util/fatal-handlers.js` by asserting the two code sets rather than reading them:

```
stream  : EPIPE, ERR_STREAM_DESTROYED, ENOTCONN, ECONNRESET
backstop: EPIPE, ERR_STREAM_DESTROYED
```

The wider set is what makes captured output quiet; the backstop deliberately excludes `ECONNRESET` and `ENOTCONN` so a reset Qlik Sense connection keeps its crash dump. That difference is exactly what the new bullet documents. `BROKEN_PIPE_EXIT_CODE` is still 141.

`npm run docs:build` passes. Anchors confirmed against generated HTML: `#engine-session-dropped-mid-run`, `#a-closed-output-pipe-is-not-a-crash`, `#exit-code-141`.

Per the draft, the troubleshooting entry and the exit-code-141 reference entry need no change — the symptom and the code are the same either way. Confirmed both.