### PR TITLE
Document that the Windows download is signed again from 5.0.0

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,9 +18,12 @@ Visit the [GitHub releases page](https://github.com/ptarmiganlabs/butler-sheet-i
 
 #### Windows
 
-- The binary is digitally signed with a commercial certificate from Certum
-- Windows may show a security warning on first run - this is normal
+- The binary is digitally signed with a commercial certificate from Certum, **from BSI 5.0.0 onwards**. Versions 4.0.0 and 4.1.0 shipped unsigned, because the previous certificate had expired
+- Windows may show a security warning on first run - this is normal, and a signature does not immediately stop it
+- The publisher name shown is a person's, not "Ptarmigan Labs" — the certificate is issued to an individual open source developer
 - No additional dependencies required
+
+See [Windows code signing](/reference/security#windows-code-signing) for how to verify the signature, what it does and does not protect against, and how to build an AppLocker or WDAC publisher rule.
 
 #### macOS
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1740,6 +1740,36 @@ It is now written at `info`, matching every other command that works on an app y
 
 ## Platform-Specific Issues
 
+### Windows warns about the publisher, or will not run the download {#windows-publisher-warning}
+
+**Symptoms:**
+
+- **Windows protected your PC** — "Microsoft Defender SmartScreen prevented an unrecognised app from starting"
+- The **Digital Signatures** tab is missing from the file's Properties
+- An AppLocker or Windows Defender Application Control publisher rule does not match the executable
+- The publisher shown is a person's name rather than "Ptarmigan Labs"
+
+**Cause and fix, by symptom:**
+
+| What you see | Why | What to do |
+| --- | --- | --- |
+| No digital signature at all | You are on **4.0.0 or 4.1.0**. The previous certificate expired shortly before 4.0.0, so those two releases shipped unsigned | Upgrade to 5.0.0 or later. No configuration change is needed |
+| SmartScreen still warns, even on a signed release | SmartScreen goes on accumulated *reputation*, not merely on whether a signature exists. Only Extended Validation certificates get reputation immediately | Choose **More info**, then **Run anyway**. It becomes less frequent as the release is downloaded more widely |
+| A publisher rule does not match | An unsigned executable cannot be permitted by a publisher rule under any configuration | Upgrade to a signed release, then build the rule from the publisher certificate rather than a file hash |
+| The publisher is a person's name | The certificate is issued to an individual open source developer rather than to a company | Expected. Confirm it with the thumbprint rather than the name |
+
+**Always confirm the thumbprint, not just the status.** `Status` reading `Valid` only means the file carries an intact signature from a certificate Windows trusts — any correctly signed program passes that test.
+
+```powershell
+$sig = Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe
+$sig | Format-List Status, StatusMessage
+$sig.SignerCertificate | Format-List Subject, Issuer, Thumbprint, NotAfter
+```
+
+The expected thumbprint, what it protects against, and how to build an AppLocker or WDAC rule are on [Windows code signing](/reference/security#windows-code-signing).
+
+If your antivirus quarantines the file even though it is signed, and you obtained it from the [official release page](https://github.com/ptarmiganlabs/butler-sheet-icons/releases), add an exclusion — a single-file executable built from the Node.js runtime is a common source of false positives.
+
 ### Windows Issues
 
 **Common Problems:**

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -10,9 +10,86 @@ If you discover a serious bug with BSI that may pose a security problem, please 
 
 ## Platform-specific notes
 
-### Windows
+### Windows {#windows-code-signing}
 
 The Windows version of Butler Sheet Icons is signed with a proper, commercial code signing certificate issued by Certum.
+
+::: warning Requires BSI 5.0.0 or later
+5.0.0 is the first release to carry the restored signature. The previous certificate expired shortly before 4.0.0, so **4.0.0 and 4.1.0 shipped without any signature at all**. If you are running one of those, upgrading is the fix — no configuration change is needed on your side.
+:::
+
+The certificate is issued to an individual open source developer rather than to a company, so the publisher name Windows shows you is a person's name, not "Ptarmigan Labs". That is normal for open source projects and does not affect what the signature guarantees. The commands below print the exact publisher string out of the release you already hold.
+
+Nothing about how Butler Sheet Icons works changed with the signature. It affects only how Windows treats the file.
+
+#### What the signature does for you
+
+**It proves where the file came from.** A valid signature confirms the executable was published by the holder of that certificate and has not been altered since — by a mirror, a proxy, or anything else between the release page and your server.
+
+**Publisher rules work again.** Many organisations enforce application control through AppLocker or Windows Defender Application Control, commonly allowing programs by publisher certificate. Those rules can match the signed release, where they could not match the unsigned 4.0.0 and 4.1.0 downloads at all — an unsigned executable cannot be permitted by a publisher rule under any configuration.
+
+If your Windows administrator created a file hash rule to allow an unsigned version, it is worth asking them to replace it with a publisher rule. A hash rule has to be updated for every new release; a publisher rule does not.
+
+**Antivirus false positives become less likely.** Butler Sheet Icons is a single-file executable built from the Node.js runtime, and that construction is a common source of false positives. A valid signature helps, though it does not guarantee anything — if your antivirus still quarantines the file and you obtained it from the official release page, add an exclusion.
+
+#### What the signature does not do
+
+**It does not immediately silence Microsoft Defender SmartScreen.**
+
+SmartScreen decides whether to warn based on the *reputation* it has accumulated for a file and its signing certificate, not merely on whether a signature exists. Only Extended Validation certificates receive reputation immediately; this is a standard code signing certificate, so reputation builds as more people download the release.
+
+In practice you may still see:
+
+> **Windows protected your PC**
+> Microsoft Defender SmartScreen prevented an unrecognised app from starting.
+
+especially in the first weeks after a new certificate is put into use. Choose **More info**, then **Run anyway**. The warning should become less frequent over time, and unlike an unsigned file, you can confirm who published it before you proceed.
+
+#### Checking the signature yourself {#checking-the-signature-yourself}
+
+Worth doing if you are deploying into a controlled environment, or confirming a download before distributing it internally. In PowerShell, in the folder holding the executable:
+
+```powershell
+$sig = Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe
+$sig | Format-List Status, StatusMessage
+$sig.SignerCertificate | Format-List Subject, Issuer, Thumbprint, NotAfter
+```
+
+You can also right-click the file, choose **Properties**, and look at the **Digital Signatures** tab.
+
+##### Check the thumbprint, not only the status
+
+`Status` reading `Valid` means the file carries an intact signature from a certificate Windows trusts. It does **not** mean the file came from us — any correctly signed program on earth passes that test. Comparing the thumbprint is what actually confirms the publisher.
+
+| | |
+| --- | --- |
+| Issuer | `CN=Certum Code Signing 2021 CA, O=Asseco Data Systems S.A., C=PL` |
+| Thumbprint | `1674DF1C6EAD6DB9D816705CD230281B87A1C97E` |
+| Valid | 2026-08-12 to 2027-08-12 |
+
+The subject line — which names the individual the certificate was issued to — is printed by the commands above from the release you already hold, so it is not reproduced here.
+
+None of this is confidential: the certificate is embedded in every signed release, so anyone holding a download can read all of it out.
+
+Two things that surprise people:
+
+- **The thumbprint is a SHA-1 hash _of the certificate_**, which has nothing to do with the SHA-256 digest used for the signature itself. Windows has identified certificates this way for years. It is not a weakness in the signature.
+- **A renewal changes the thumbprint.** Releases signed before 2026-08-12 carry an older certificate, and releases after 2027-08-12 will carry its replacement. If the thumbprint does not match, check this page before assuming the worst.
+
+##### Building an application control rule
+
+If you allow programs by publisher through AppLocker or Windows Defender Application Control, you can build the rule from the publisher certificate rather than from a specific binary. Export it from any signed release:
+
+```powershell
+$sig = Get-AuthenticodeSignature -LiteralPath .\butler-sheet-icons.exe
+[System.IO.File]::WriteAllBytes("$PWD\butler-sheet-icons-publisher.cer", $sig.SignerCertificate.RawData)
+```
+
+That `.cer` file is what `Add-SignerRule` expects when adding a signer to a WDAC policy. Prefer it to a file hash rule: a publisher rule keeps working across releases, while a hash rule has to be updated for every new version.
+
+One point worth understanding: **the signature is timestamped**. It therefore stays valid after the signing certificate itself expires, so a release downloaded years from now still verifies. Without a timestamp, every previously released binary would stop validating the day the certificate lapsed.
+
+A valid signature proves the publisher, not the download source. Always download from the [official release page](https://github.com/ptarmiganlabs/butler-sheet-icons/releases).
 
 ### macOS
 


### PR DESCRIPTION
Publishes `docs/to-doc-site/windows-binary-signed-again.md` from the BSI repo.

## ⚠️ Release-time condition — this must be checked before `next` is merged to `main`

This page **tells administrators the Windows download is signed**. Windows signing can fail silently in a way that still produces a release: on 2026-08-13 every insiders build was unsigned for about 23 hours because a SimplySign session had expired, while the signing precheck still reported the certificate as usable.

Before `next` reaches `main` at release time, confirm the **published 5.0.0 Windows asset** really carries a signature, by running `Get-AuthenticodeSignature` on the actual release download — **not** by trusting the CI log.

Safe to sit on `next` in the meantime: `next` only reaches the public site when it is merged at release.

## What is published

**`reference/security.md`** — the Windows section, previously a single sentence, now covers what the signature does and does not do, SmartScreen reputation, verifying it, and building an AppLocker/WDAC publisher rule.

**`guide/installation.md`** — the Windows platform notes now state the 5.0.0 gate and that 4.0.0/4.1.0 were unsigned.

**`guide/troubleshooting.md`** — new "Windows warns about the publisher" entry, as a symptom→cause→fix table.

## Corrections to text already live

Both `security.md` and `installation.md` stated flatly that the Windows binary is signed, with no version qualification. For anyone on 4.0.0 or 4.1.0 that was misleading — those releases are unsigned, and the page gave them no way to know that was expected.

## Privacy

The certificate holder's name and the full subject DN are **not** printed, consistent with `ded6c35` ("docs: drop the certificate holder's name from the Windows signing note"). The staged draft printed both, including the maintainer's home locality. The page says instead that the certificate is issued to an individual open source developer rather than a company, and the PowerShell snippets read the exact subject out of the reader's own download. Verified zero occurrences of the name or locality across all three pages.

## Verification

- `npm run docs:build` passes. Anchors confirmed against generated HTML: `#windows-code-signing`, `#checking-the-signature-yourself`, `#windows-publisher-warning`.
- **4.0.0 and 4.1.0 unsigned, 5.0.0 first signed** — verified independently: 4.1.0 shipped 2026-08-11 and the certificate was issued 2026-08-12, so no released version can carry it.
- Version gate 5.0.0 read from release-please PR #974.
- **Not verified: the thumbprint, issuer and validity dates.** `WIN_CODESIGN_THUMBPRINT` is a repository secret, so it is masked in workflow logs and not present in the repo. Those three values come from the draft's 2026-08-12 signing-host run. Re-confirm them as part of the release-time check above.