### PR TITLE
Correct where the browser cache lives on the browser reference page

### DIFF
--- a/docs/reference/browser.md
+++ b/docs/reference/browser.md
@@ -733,15 +733,26 @@ butler-sheet-icons qseow create-sheet-thumbnails \
 
 ## Browser Cache Location
 
-BSI stores browsers in a cache directory under the home directory of the user running BSI:
+BSI keeps the browsers it downloads in a cache directory. Where that is depends on how you run it — the first of these that is set wins:
 
-- **Windows:** `%USERPROFILE%\.cache\puppeteer\`
-- **macOS:** `~/.cache/puppeteer/`
-- **Linux:** `~/.cache/puppeteer/`
+| Order | Location | Set by |
+| --- | --- | --- |
+| 1 | The directory you name | `--browser-cache-dir <directory>` or `BSI_BROWSER_CACHE_DIR` |
+| 2 | The directory `PUPPETEER_CACHE_DIR` names | `PUPPETEER_CACHE_DIR` |
+| 3 | `browser-cache` next to `butler-sheet-icons(.exe)` | Automatic, **standalone builds only** |
+| 4 | `.cache/puppeteer` in the current user's home directory | Automatic, everything else |
 
-These directories contain the actual browser binaries and are managed automatically by BSI.
+::: warning Requires BSI 5.0.0 or later
+In earlier versions the cache was always `.cache/puppeteer` in the home directory of whichever account ran BSI. There was no way to change it, and `PUPPETEER_CACHE_DIR` was ignored.
+:::
 
-Because the cache lives under the user's home directory, a browser installed by one user account is not visible to another. When BSI runs as a service account — for example from a scheduled task — install the browser as that same account, or point all accounts at one shared browser with `PUPPETEER_EXECUTABLE_PATH`.
+These directories hold the actual browser binaries and are managed automatically by BSI.
+
+The difference between the two automatic locations matters on a Qlik Sense server. Row 4 follows the **account**: a browser installed by one user is not visible to another, so a scheduled task running as LocalSystem looks in `C:\Windows\system32\config\systemprofile` rather than in your profile, finds nothing, and downloads its own copy — or fails, on a server with no internet access. Row 3 follows the **installation** instead, which is why the standalone builds use it: everyone who runs that copy of BSI gets the same browser.
+
+To make the location the same for every account, name it explicitly with `--browser-cache-dir` or `BSI_BROWSER_CACHE_DIR` rather than relying on either default. [`browser check`](#check) reports the directory BSI resolved, which account it resolved it as, and which builds are in it.
+
+See [Browser Cache Directory](/guide/advanced/browser-cache-directory) for the full picture, including what happens when a browser is still in the pre-5.0.0 location.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

The `## Browser Cache Location` section of `/reference/browser` still described pre-5.0.0 behaviour — the cache always under the home directory of the account running BSI. Three things were wrong with it:

1. **It named only the home directory.** Per `describeBrowserCacheDir` in `src/lib/browser/browser-paths.js`, there are four tiers, and the standalone builds keep the cache in `browser-cache` next to the executable. That is how most Qlik Sense servers run BSI, so the page named the wrong directory for its main audience.
2. **It never mentioned `--browser-cache-dir` / `BSI_BROWSER_CACHE_DIR` or `PUPPETEER_CACHE_DIR`** — the settings that actually solve the service-account problem were absent from the section explaining where the cache lives.
3. **Its closing advice was outdated and conflated two things.** It suggested pointing all accounts at one shared browser with `PUPPETEER_EXECUTABLE_PATH`, which names an executable rather than a cache, and is now the lowest-priority way to do even that.

The section contradicted two things on its own page: the generated `--browser-cache-dir` option table, which states both defaults correctly, and the `browser check` example added in #99, whose output reads `Source: default location next to the Butler Sheet Icons executable`.

Replaced with the same four-tier precedence table `/guide/advanced/browser-cache-directory` uses, gated at 5.0.0 to match that page, plus a short explanation of why the two automatic locations differ — one follows the account, the other the installation — and a pointer to the dedicated page rather than a second copy of it.

## Type of change

- [x] Fix (typo, broken link, incorrect information)
- [ ] Content update (new information or examples on an existing page)
- [ ] New page
- [ ] Enhancement (clearer explanation, reorganisation)
- [ ] Repository/tooling change (config, workflows, dependencies)

## Pages affected

`/reference/browser` — the `## Browser Cache Location` section only. One file, +17/−6.

## Checklist

- [x] This PR targets `next`
- [x] `npm run docs:build` passes locally (the build fails on dead internal links)
- [x] Internal links are absolute and extensionless
- [x] New pages have a sidebar entry in `docs/.vitepress/config.js` — n/a, no new pages
- [x] Images display correctly and have descriptive alt text — n/a, no images
- [ ] Checked the Cloudflare Pages preview link once the build finishes

## Notes for reviewers

**Verified against the source, not against the other page.** The precedence comes from the documented tiers in `describeBrowserCacheDir`: `--browser-cache-dir` / `BSI_BROWSER_CACHE_DIR`, then `PUPPETEER_CACHE_DIR`, then `browser-cache` next to the executable for standalone builds only, then `.cache/puppeteer` in the home directory. A live `browser check` run on a non-standalone install reports `Source: default location` → `~/.cache/puppeteer`, which is tier 4 behaving as documented.

**Checked whether the same error appears elsewhere.** Eight pages mention `.cache/puppeteer`; the other seven are correctly scoped — the concept page's row is explicitly labelled "From Node.js", the examples are Mac sample output and a Docker mount, and the qseow/qscloud generated option tables already describe both defaults. This section was the only stale one.

`docs:cli-tables --check` still reports all six generated tables on the page as current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)