### PR TITLE
Say that repeating a sheet-icon removal is a no-op

### DIFF
--- a/docs/guide/concepts/dry-run.md
+++ b/docs/guide/concepts/dry-run.md
@@ -140,7 +140,10 @@ Things to check before running for real:
   The exit code is 1 in that case.
 
 For the two `remove-sheet-icons` commands the column reads `clear icon` instead, and sheets
-that currently have no icon are marked `(no icon currently set)`.
+that currently have no icon are marked `(no icon currently set)`. The real run agrees with that
+row rather than contradicting it: it skips those sheets instead of clearing something already
+clear, so a removal repeated over an app it has already cleared writes nothing and does not save
+the app.
 
 The two platforms differ in what else is removed, and the plan says so. On Qlik Sense Cloud
 each app's section also shows how many thumbnail files would be deleted from the app's media

--- a/docs/reference/qseow.md
+++ b/docs/reference/qseow.md
@@ -164,6 +164,8 @@ The image files a previous thumbnail run uploaded to the content library are **n
 
 Before anything is written, the run prints a plan: the server, the identity it connects as, how many apps matched your selection, how many of those are published, and a line stating what is about to happen. That published count is worth reading — the icons are cleared in memory and then the app is saved, and it is the save that a published app refuses.
 
+Sheets that have no icon are marked `(no icon currently set)` in the plan, and the run treats them the same way: it skips them rather than clearing something that is already clear. That makes the command safe to repeat. Running it a second time over an app it has already cleared reports every sheet as having no icon, writes nothing, and does not save the app — so it does not show up as a change to a published app.
+
 ### Fewer options than creating thumbnails
 
 Creating a thumbnail means opening each sheet in a browser and photographing it, which is why that command needs web UI logon credentials, a browser and a page-wait time. Clearing an icon changes a property over the engine connection, so none of that applies here and none of it is offered:


### PR DESCRIPTION
Adds back a sentence that was deliberately withheld when these pages were published, now that the behaviour it describes is real.

## Background

The staged draft claimed the real run reports no-icon sheets the same way the dry run does. When PR #109 was published that was **false** — the run tested for the thumbnail *structure* while the plan tested the *URL*, so a repeat run over an already-cleared app rewrote and saved every sheet (ptarmiganlabs/butler-sheet-icons#1113). The sentence was left out rather than published as a wrong claim.

#1113 was then fixed in ptarmiganlabs/butler-sheet-icons#1114, the same PR that merged the draft, and it ships in the 5.0.0 release these pages are already gated on. So no new version gate is needed.

## What changed

Stated more usefully than the draft put it. An administrator does not care that two outputs agree; they care whether the command is safe to run twice. Both pages now say that a repeat run skips those sheets, writes nothing, and does not save the app — so it does not surface as a change to a published app.

- `/reference/qseow`, in the `remove-sheet-icons` "How it works" section.
- `/guide/concepts/dry-run`, where the removal column is described, so the plan/run parity is stated where the plan is explained.

## Verification

Against the lab, after the fix: a second removal over an already-cleared app reported `9 seen, 0 icon(s) cleared, 9 had no icon`, and a QRS snapshot of every sheet's `modifiedDate` was byte-identical before and after. The control case — a removal that does clear icons — moved the date on exactly the 8 sheets it cleared, so the snapshot distinguishes the two cases rather than being a metric that never moves.

`npm run docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)