### PR TITLE
Publish the live run view page and the removal dry-run summary change

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -122,6 +122,7 @@ export default withMermaid({
               text: "The Contact Sheet",
               link: "/guide/concepts/contact-sheet",
             },
+            { text: "The Live View", link: "/guide/concepts/live-view" },
             {
               text: "App Overview Screenshots",
               link: "/guide/concepts/app-overview-screenshots",

--- a/docs/guide/concepts/contact-sheet.md
+++ b/docs/guide/concepts/contact-sheet.md
@@ -72,12 +72,12 @@ write with no undo.
 The row of block characters after each app name is a **sheet strip**: one character per
 sheet, in sheet order.
 
-| Character | ASCII fallback | Meaning on a thumbnail run                | Meaning on `remove-sheet-icons`      |
-| --------- | -------------- | ----------------------------------------- | ------------------------------------ |
-| `█`       | `#`            | Sheet captured and its thumbnail uploaded | Sheet icon cleared                   |
-| `▓`       | `:`            | Captured, then blurred                    | —                                    |
-| `░`       | `.`            | Excluded by one of your exclude rules     | Sheet had no icon to clear           |
-| `▒`       | `!`            | Not processed — the app failed here       | Not processed — the app failed here  |
+| Character | ASCII fallback | Meaning on a thumbnail run                | Meaning on `remove-sheet-icons`     |
+| --------- | -------------- | ----------------------------------------- | ----------------------------------- |
+| `█`       | `#`            | Sheet captured and its thumbnail uploaded | Sheet icon cleared                  |
+| `▓`       | `:`            | Captured, then blurred                    | —                                   |
+| `░`       | `.`            | Excluded by one of your exclude rules     | Sheet had no icon to clear          |
+| `▒`       | `!`            | Not processed — the app failed here       | Not processed — the app failed here |
 
 This makes selection mistakes visible per app, at a glance. A mistyped
 `--exclude-sheet-tag` shows up as a row of solid blocks where you expected gaps. A
@@ -116,12 +116,12 @@ too; the detailed per-sheet dry-run report itself is unchanged.
 `BSI_OUTPUT` is an environment variable, like `BSI_ASCII_ONLY` and `BSI_NO_INTERACTIVE`:
 it describes your console, not one invocation, so it is not a per-command flag.
 
-| Value   | Effect                                                                                                                                              |
-| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `board` | Force the contact sheet, even where detection would not pick it (for example, when recording a run, or on a terminal that is detected incorrectly)   |
-| `plain` | Force the plain run card                                                                                                                             |
-| `off`   | Suppress the framed plan and verdict blocks entirely. Per-app and per-sheet progress lines still print, so the run is not silent                     |
-| `live`  | Reserved for a future live view; today it behaves like automatic selection                                                                           |
+| Value   | Effect                                                                                                                                                                                   |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `board` | Force the contact sheet, even where detection would not pick it (for example, when recording a run, or on a terminal that is detected incorrectly)                                       |
+| `plain` | Force the plain run card                                                                                                                                                                 |
+| `off`   | Suppress the framed plan and verdict blocks entirely. Per-app and per-sheet progress lines still print, so the run is not silent                                                         |
+| `live`  | Permission for the [live view](/guide/concepts/live-view), not a force — it is one of that view's conditions, and can never point a repainting display at a stream that cannot render it |
 
 Values are case-insensitive. An unrecognised value logs a warning and falls back to
 automatic selection — it never stops the run, so a typo in a scheduler's environment
@@ -162,7 +162,7 @@ BSI_OUTPUT=off ./butler-sheet-icons qscloud create-sheet-thumbnails ...
 
 ## Scheduled and captured runs are unaffected
 
-The contact sheet is only ever what an interactive terminal *sees*. Redirected output is
+The contact sheet is only ever what an interactive terminal _sees_. Redirected output is
 not a terminal, so a redirected or scheduled run selects the
 [plain run card](/guide/concepts/run-card) automatically — a file, a Task Scheduler
 transcript or a captured CI log gets the run card, never the board. And when the contact

--- a/docs/guide/concepts/dry-run.md
+++ b/docs/guide/concepts/dry-run.md
@@ -145,6 +145,24 @@ row rather than contradicting it: it skips those sheets instead of clearing some
 clear, so a removal repeated over an app it has already cleared writes nothing and does not save
 the app.
 
+The summary line counts them the same way, so the plan and the run it predicts state the same
+numbers. On an app with nine sheets, eight of which carry an icon:
+
+```
+Summary: 1 app(s), 9 sheets. 8 icon(s) would be cleared, 1 with no icon, 0 skipped.
+```
+
+and the real run on that app reports the matching split:
+
+```
+  sheets        9 seen, 8 icon(s) cleared, 1 had no icon
+```
+
+The `with no icon` part appears only when there is at least one such sheet. It is worth reading
+before a repeat removal: over an app that has already been cleared the plan reads
+`0 icon(s) would be cleared, 9 with no icon`, which says plainly that the run would write
+nothing — rather than appearing to promise a fresh sweep.
+
 The two platforms differ in what else is removed, and the plan says so. On Qlik Sense Cloud
 each app's section also shows how many thumbnail files would be deleted from the app's media
 library, as `N thumbnail media file(s) would also be deleted from the app media library`. On
@@ -157,7 +175,7 @@ Neither removal command has exclude or blur rules, so there are none to apply.
 
 - **It does not verify the web UI login.** No browser is started, so the
   `--logonuserdir`/`--logonuserid`/`--logonpwd` credentials (and the Cloud login) are never
-  exercised. On client-managed Qlik Sense the certificate and repository API path *is*
+  exercised. On client-managed Qlik Sense the certificate and repository API path _is_
   exercised — those are different credentials.
 - **It does not check that `--imagedir` is writable.** Creating the image directory is a
   write, so a dry run never attempts it. A real run in Docker can still fail on a

--- a/docs/guide/concepts/live-view.md
+++ b/docs/guide/concepts/live-view.md
@@ -1,0 +1,125 @@
+# Live run view: watching a thumbnail run as it happens
+
+::: warning Requires BSI 5.0.0 or later
+Earlier versions show the contact sheet in interactive terminals. The animated live
+view arrives in this version.
+:::
+
+When you run `qseow create-sheet-thumbnails` or `qscloud create-sheet-thumbnails` in an
+interactive terminal, Butler Sheet Icons now shows a **live view** of the run: each
+connection step resolves on screen as it actually completes, a progress bar follows the
+sheets of the app being processed, and the display collapses into the familiar verdict
+line when the run ends.
+
+A thumbnail run spends most of its time waiting — on a browser, on a login, on each
+sheet rendering. With `--pagewait` at its default of 5 seconds, a seven-app run is six
+minutes during which the only question that matters is _"is it alive, and how far in is
+it?"_ The live view answers that at a glance, which the scrolling log lines never did.
+
+## What it looks like
+
+The run opens with the same wordmark frame as the contact sheet. The preflight steps
+then resolve one at a time, each with a spinner while its real work is in flight and a
+check mark when it has actually finished. The first three rows — certificates, content
+library, app list — appear before the `PLAN` block (the plan can only be stated once
+the app list is known); the browser and sign-in rows resolve below it, as the first
+app starts:
+
+```
+  ✓ certificates      client.pem · client_key.pem
+  ✓ content library   "Butler sheet thumbnails" exists
+  ✓ app list          3 apps · 1 named · 2 tagged
+  ✓ browser           chrome · from cache
+  ⠹ signed in
+```
+
+These rows are not an animation played over the log — each one is tied to the real
+operation behind it. The `certificates` row resolves when the certificate files have
+been read, `content library` when the Qlik Sense server has confirmed the library
+exists, `browser` when the browser has started **and answered its first command**, and
+`signed in` only once the login has completed and the app has loaded. If a run hangs,
+the row that never resolves tells you exactly which step it is stuck on — that is the
+main reason this view exists.
+
+While each app is processed, a progress bar follows its sheets, driven by the same
+per-sheet records the final summary is counted from:
+
+```
+  app 2/3  Executive KPIs · 9 sheets
+  ██████████████░░░░░░░░░░░░  5/9  'Sheet 4'
+  ░████
+```
+
+The short row of blocks under the bar is the app's **sheet strip** growing in real
+time, with the same meaning as on the contact sheet: `█` captured, `▓` blurred, `░`
+excluded by one of your rules. As each app finishes, its strip row is written
+permanently to the terminal, exactly as the contact sheet prints it:
+
+```
+  ✓ 1/3  Sales Discovery       ░████████     8/9 up        1m 8s
+```
+
+And at the end the animation stops, the cursor comes back, and the run closes with the
+verdict:
+
+```
+  ────────────────────────────────────────────────────────────────
+
+  ❯ done in 2m 21s  ·  3 app(s) ok  ·  24 thumbnails uploaded
+    █ 24 captured   ▓ 2 blurred   ░ 3 excluded
+    images in ./img/qseow · 48 file(s) · 2.5 MB
+```
+
+If the browser needs to be downloaded mid-run — the first run on a new machine, or
+after changing `--browser-version` — the download shows up as a
+`downloading browser 42%` label in the same display. There is no separate download
+progress bar fighting the live view for the terminal.
+
+Warnings and errors are not hidden by the animation: they are written permanently above
+it, in order, as they happen. An app that fails mid-run shows a red row in the list and
+is counted in the verdict, just as on the contact sheet.
+
+## When you get it — and when you deliberately do not
+
+The live view has the strictest requirements of Butler Sheet Icons' output styles,
+because a repainting display is only safe on a real terminal. You get it when **all**
+of these hold:
+
+- output goes to an interactive terminal (not a file, a pipe, or a scheduler),
+- the terminal is at least 80 characters wide and 24 rows tall, supports colour, and
+  is not `TERM=dumb`,
+- the log level is the default `info` — at `--log-level verbose` or `debug` you asked
+  to read log lines, and at `warn` or `error` you asked for quiet,
+- the browser runs headless (with `--headless false` a visible browser window is the
+  thing you chose to watch),
+- it is a real run, not `--dry-run` — a dry run finishes in seconds and its product is
+  the plan text.
+
+When a condition is not met, the output falls back to the **contact sheet** where the
+terminal can still render static colour, and otherwise to the **plain run card**. Two
+of the conditions skip the contact sheet entirely: any log level other than `info`,
+and a stream that is not an interactive terminal, both go straight to the plain run
+card — so redirected and scheduled output never contains a single repaint frame, and
+`docker logs`, cron mail and captured log files stay readable. Both `remove-sheet-icons` commands keep the contact sheet: an icon
+removal has no browser and no page waits, so there is nothing to watch.
+
+The `BSI_OUTPUT` environment variable works as documented on the contact-sheet page:
+`off`, `plain` and `board` are absolute and always honoured, and `BSI_OUTPUT=live`
+remains a _permission_, not a force — it can never point cursor animation at a stream
+that cannot render it.
+
+The view was verified on the oldest console Butler Sheet Icons supports: Windows
+Server 2019's conhost renders the in-place updates cleanly under both PowerShell 5.1
+and cmd.exe, so no special terminal is needed on Windows.
+
+## If the terminal ever looks wrong
+
+The live view restores the terminal — cursor visible, output back to normal — when a
+run completes, when it fails, and when Butler Sheet Icons crashes. One case is not yet
+covered: **stopping a run with Ctrl-C** (or killing the process any other way) ends it
+before the cleanup can run, and can leave the cursor invisible. The standard `reset`
+command restores the terminal; graceful Ctrl-C handling is planned separately.
+
+If your console renders the animation as garbage (an unusual terminal emulator, an
+over-SSH session with a broken `TERM`), set `BSI_OUTPUT=board` or `BSI_OUTPUT=plain`
+for that environment and the run will use the static styles instead.


### PR DESCRIPTION
Publishes the last two staged drafts from the main repo's `docs/to-doc-site/`.

## The live run view

New Core Concepts page, [The Live View](/guide/concepts/live-view), with a sidebar entry beside the contact sheet it builds on. It covers what the display shows, how each preflight row is tied to the real operation behind it (so a hung run names the step it is stuck on), and the conditions under which you get it — interactive terminal, 80×24, colour, `TERM` not `dumb`, log level `info`, headless browser, real run.

It also **corrects the contact-sheet page**, whose `BSI_OUTPUT` table still said `live` was "reserved for a future live view; today it behaves like automatic selection". That value is now one of the live view's own conditions: a permission rather than a force, and never a way to point a repainting display at a stream that cannot render it.

Two of the draft's claims were checked against the source before publishing rather than taken on trust, and one was stale:

- **Corrected.** The draft said `qscloud remove-sheet-icons` keeps the contact sheet. It was written before `qseow remove-sheet-icons` existed; both do. Only the two `create-sheet-thumbnails` workers ever call `startLiveRunView`, so the page now names both removal commands.
- **Still true.** The Ctrl-C caveat. There is no `SIGINT` or `SIGTERM` handler anywhere in the source, so an interrupted run can still leave the cursor hidden — while completion, failure and crash all restore the terminal through `restoreLiveTerminal`.

## The removal dry run's summary

A short addition to the dry-run page. The summary now counts icons that would be cleared separately from sheets that have none, so the plan and the run it predicts state the same numbers. Both transcripts are shown together.

The sample was taken from the committed snapshot in the main repo, which is generated from a real run against a lab server, rather than written by hand: `Summary: 1 app(s), 9 sheets. 8 icon(s) would be cleared, 1 with no icon, 0 skipped.`

The repeat case is called out, since it is the one most likely to mislead — over an already-cleared app the plan reads `0 icon(s) would be cleared, 9 with no icon`, which says the run would write nothing rather than appearing to promise a fresh sweep.

`npm run docs:build` passes, so no dead links. Targeting `next`, as all doc-site work does.
